### PR TITLE
Update to 1.21.130, support use of non-numerical network IDs for Realms

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3,9 +3,6 @@ package nethernet
 import (
 	"errors"
 	"fmt"
-	"github.com/pion/ice/v4"
-	"github.com/pion/sdp/v3"
-	"github.com/pion/webrtc/v4"
 	"io"
 	"log/slog"
 	"math/rand"
@@ -15,6 +12,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pion/ice/v4"
+	"github.com/pion/sdp/v3"
+	"github.com/pion/webrtc/v4"
 )
 
 // Conn is an implementation of [net.Conn] for a peer connection between a specific remote
@@ -63,8 +64,9 @@ type Conn struct {
 
 	log *slog.Logger
 
-	local         Addr
-	id, networkID uint64
+	local     Addr
+	id        uint64
+	networkID string
 }
 
 // Read receives a message from the 'ReliableDataChannel'. The bytes of the message data are copied to
@@ -462,7 +464,7 @@ func (desc description) connectionRole(role webrtc.DTLSRole) sdp.ConnectionRole 
 // a [slog.Logger] of the Conn, and few other methods to handle events such as closures. The
 // negotiator (caller) must establish each transport after creating a Conn when a first ICE
 // candidate has been signaled from the remote connection.
-func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.SCTPTransport, id, networkID uint64, local Addr, n negotiator) *Conn {
+func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.SCTPTransport, id uint64, networkID string, local Addr, n negotiator) *Conn {
 	return &Conn{
 		ice:  ice,
 		dtls: dtls,
@@ -480,7 +482,7 @@ func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.
 
 		log: n.log().With(slog.Group("connection",
 			slog.Uint64("id", id),
-			slog.Uint64("networkID", networkID),
+			slog.String("networkID", networkID),
 		)),
 
 		local: local,

--- a/dial.go
+++ b/dial.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/pion/sdp/v3"
-	"github.com/pion/webrtc/v4"
 	"log/slog"
 	"math/rand"
 	"strconv"
+
+	"github.com/pion/sdp/v3"
+	"github.com/pion/webrtc/v4"
 )
 
 // Dialer encapsulates options for establishing a connection with a NetherNet network through [Dialer.DialContext]
@@ -35,7 +36,7 @@ type Dialer struct {
 // the remote connection. The [context.Context] may be used to cancel the connection as soon as possible. If the [context.Context]
 // is done, and [context.Context.Err] returns [context.DeadlineExceeded], it signals back a Signal of SignalTypeError with ErrorCodeInactivityTimeout
 // or ErrorCodeNegotiationTimeoutWaitingForAccept based on the progress. A Conn may be returned, that is ready to receive and send packets.
-func (d Dialer) DialContext(ctx context.Context, networkID uint64, signaling Signaling) (*Conn, error) {
+func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Signaling) (*Conn, error) {
 	if d.ConnectionID == 0 {
 		d.ConnectionID = rand.Uint64()
 	}
@@ -205,7 +206,7 @@ func (d dialerConn) log() *slog.Logger {
 // signalError signals a Signal of SignalTypeError into the remote connection using the
 // [Signaling] implementation with the remote network ID and the code of the error
 // occurred.
-func (d Dialer) signalError(signaling Signaling, networkID uint64, code int) {
+func (d Dialer) signalError(signaling Signaling, networkID string, code int) {
 	_ = signaling.Signal(&Signal{
 		Type:         SignalTypeError,
 		Data:         strconv.Itoa(code),
@@ -290,7 +291,7 @@ func (d Dialer) handleConn(ctx context.Context, conn *Conn, signals <-chan *Sign
 // notifySignals registers dialerNotifier to the Signaling to receive notifications of incoming Signals that has
 // the same network ID and same ConnectionID of Dialer. A *dialerNotifier and a function to stop receiving notifications
 // will be returned.
-func (d Dialer) notifySignals(networkID uint64, signaling Signaling) (*dialerNotifier, func()) {
+func (d Dialer) notifySignals(networkID string, signaling Signaling) (*dialerNotifier, func()) {
 	n := &dialerNotifier{
 		Dialer: d,
 
@@ -311,7 +312,7 @@ type dialerNotifier struct {
 	errs    chan error    // Notifies error occurred in Signaling
 	closed  chan struct{} // Notifies that dialerNotifier is closed, and ensures that closure occur only once
 
-	networkID uint64 // Remote network ID
+	networkID string // Remote network ID
 }
 
 func (d *dialerNotifier) NotifySignal(signal *Signal) {

--- a/dial.go
+++ b/dial.go
@@ -186,8 +186,8 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 type dialerConn struct {
 	Dialer
 
-	// stop is the function without parameters which is returned by [Signaling.Notify]
-	// to stop receiving notifications in Notifier from Signaling.
+	// stop is a function that can be called without parameters, which is returned by
+	// [Signaling.Notify] to stop notifying signals from Signaling.
 	stop func()
 }
 

--- a/discovery/crypto.go
+++ b/discovery/crypto.go
@@ -5,12 +5,15 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+
 	"github.com/andreburgaud/crypt2go/ecb"
 	"github.com/andreburgaud/crypt2go/padding"
 )
 
+// key is the encryption key used for packets transmitted during LAN discovery.
 var key = sha256.Sum256(binary.LittleEndian.AppendUint64(nil, 0xdeadbeef)) // 0xdeadbeef is also referenced as Application ID
 
+// encrypt encrypts the content of the bytes using AES-ECB with PKCS7 padding.
 func encrypt(src []byte) []byte {
 	block, _ := aes.NewCipher(key[:])
 	mode := ecb.NewECBEncrypter(block)
@@ -21,6 +24,7 @@ func encrypt(src []byte) []byte {
 	return dst
 }
 
+// decrypt decrypts the content of the bytes using AES-ECB with PKCS7 padding.
 func decrypt(src []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key[:])
 	if err != nil {

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -102,7 +102,7 @@ type Listener struct {
 	// by addressesMu for atomic access in concurrent goroutines like background and
 	// handlePacket.
 	addresses   map[uint64]address
-	addressesMu sync.RWMutex // guards addresses
+	addressesMu sync.RWMutex
 
 	// notifyCount counts the total notifiers registered for the Listener.
 	// It is used as the ID for [nethernet.Notifier] and should not be decreased at all.

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -106,17 +106,20 @@ type Listener struct {
 
 	// notifyCount counts the total notifiers registered for the Listener.
 	// It is used as the ID for [nethernet.Notifier] and should not be decreased at all.
+	// notifyCount should be atomically accessed by holding a lock on notifiersMu.
 	notifyCount uint32
 	notifiers   map[uint32]nethernet.Notifier
-	notifiersMu sync.RWMutex // guards notifiers and notifyCount
+	notifiersMu sync.RWMutex
 
 	// responses stores a map whose keys are NetherNet network IDs which value is an
 	// application-specific data sent as ResponsePacket from the servers in the network.
 	responses   map[uint64][]byte
 	responsesMu sync.RWMutex
 
-	closed chan struct{} // I assume there's no reason for using context
-	once   sync.Once     // once ensures the Listener is closed only once.
+	// closed is a channel that is closed when the Listener closes.
+	closed chan struct{}
+	// once ensures the Listener is closed only once.
+	once sync.Once
 }
 
 // Signal sends a NetherNet signal to the corresponding address for the network ID.

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/df-mc/go-nethernet"
 	"log/slog"
 	"maps"
 	"math/rand"
@@ -15,22 +14,38 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/df-mc/go-nethernet"
 )
 
 type ListenConfig struct {
-	NetworkID        uint64
-	BroadcastAddress net.Addr
-	Log              *slog.Logger
+	// NetworkID specifies the network ID for the NetherNet network being announced to the clients in the
+	// same network. In NetherNet, it is explicitly defined as a string, but in LAN discovery it is sent as an uint8.
+	NetworkID uint64
+	// BroadcastAddress specifies the UDP broadcast address for sending request packets to the servers in
+	// the same network. If nil, an *net.UDPAddr with net.IPv4bcast and port 7551 will be used.
+	BroadcastAddress *net.UDPAddr
+	// Log is used for logging messages at various levels.
+	Log *slog.Logger
 }
 
-func (conf ListenConfig) Listen(network string, addr string) (*Listener, error) {
+// Listen starts listening on the specified address. For servers, it should be typically composed for using port
+// 7551 to respond from request packets broadcasted from clients. For clients, it can be an empty string or any
+// address with any port, as it doesn't need to response with other clients; when you expect that port 7551 is
+// already in use by the game itself, you might want to specify the address in this way.
+func (conf ListenConfig) Listen(addr string) (*Listener, error) {
 	if conf.Log == nil {
 		conf.Log = slog.Default()
 	}
 	if conf.NetworkID == 0 {
 		conf.NetworkID = rand.Uint64()
 	}
-	conn, err := net.ListenPacket(network, addr)
+	addrPort, err := netip.ParseAddrPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("parse address: %w", err)
+	}
+	// We hardcode network protocol for "udp" as it always expects UDP packets to be received.
+	conn, err := net.ListenPacket("udp", addr)
 	if err != nil {
 		return nil, err
 	}
@@ -43,15 +58,18 @@ func (conf ListenConfig) Listen(network string, addr string) (*Listener, error) 
 		addresses: make(map[uint64]address),
 
 		notifiers: make(map[uint32]nethernet.Notifier),
+		responses: make(map[uint64][]byte),
 
 		closed: make(chan struct{}),
 	}
 	go l.listen()
 
-	if conf.BroadcastAddress == nil {
-		l.conf.BroadcastAddress, err = broadcastAddress()
-		if err != nil {
-			conf.Log.Error("error resolving address for broadcast: local rooms may not be returned", slog.Any("error", err))
+	if conf.BroadcastAddress == nil && addrPort.Port() != 7551 {
+		// If the port for the address is 7551, it means no applications are listening on this network
+		// and server discovery using limited broadcast on net.IPv4bcast is not meaningful.
+		conf.BroadcastAddress = &net.UDPAddr{
+			IP:   net.IPv4bcast,
+			Port: 7551,
 		}
 	}
 	go l.background()
@@ -59,82 +77,74 @@ func (conf ListenConfig) Listen(network string, addr string) (*Listener, error) 
 	return l, nil
 }
 
-func broadcastAddress() (net.Addr, error) {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-	for _, i := range interfaces {
-		addresses, err := i.Addrs()
-		if err != nil {
-			return nil, err
-		}
-		for _, addr := range addresses {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
-			}
-			ip := ipNet.IP.To4()
-			if ip == nil {
-				continue
-			}
-			if ipNet.IP.IsPrivate() || ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() {
-				continue
-			}
-
-			broadcast := make(net.IP, 4)
-			for j := 0; j < 4; j++ {
-				broadcast[j] = ip[j] | ^ipNet.Mask[j]
-			}
-			return &net.UDPAddr{IP: broadcast, Port: 7551}, nil
-		}
-	}
-	return nil, fmt.Errorf("no suitable broadcast address found")
-}
-
+// Listener represents a listener for LAN discovery. It uses UDP as the underlying protocol
+// and allows both discovering servers on the network using broadcast or announcing servers
+// to the clients in the network.
 type Listener struct {
 	conn net.PacketConn
 
+	// conf is the ListenConfig used for [ListenConfig.Listen].
 	conf ListenConfig
 
+	// pongData atomically stores the application data for responding to the clients
+	// broadcasting RequestPacket with a ResponsePacket containing the same data.
+	// Since it is specific to applications, it is not represented in ServerData
+	// and instead []byte.
 	pongData atomic.Pointer[[]byte]
 
-	addressesMu sync.RWMutex
+	// addresses stores a map whose keys are NetherNet network IDs and the value
+	// is an address struct, which stores the UDP address for the NetherNet network
+	// ID along with the timestamp for expiring inactivity addresses. It is guarded
+	// by addressesMu for atomic access in concurrent goroutines like background and
+	// handlePacket.
 	addresses   map[uint64]address
+	addressesMu sync.RWMutex // guards addresses
 
+	// notifyCount counts the total notifiers registered for the Listener.
+	// It is used as the ID for [nethernet.Notifier] and should not be decreased at all.
 	notifyCount uint32
 	notifiers   map[uint32]nethernet.Notifier
-	notifiersMu sync.RWMutex
+	notifiersMu sync.RWMutex // guards notifiers and notifyCount
 
-	responsesMu sync.RWMutex
+	// responses stores a map whose keys are NetherNet network IDs which value is an
+	// application-specific data sent as ResponsePacket from the servers in the network.
 	responses   map[uint64][]byte
+	responsesMu sync.RWMutex
 
-	closed chan struct{}
-	once   sync.Once
+	closed chan struct{} // I assume there's no reason for using context
+	once   sync.Once     // once ensures the Listener is closed only once.
 }
 
+// Signal sends a NetherNet signal to the corresponding address for the network ID.
 func (l *Listener) Signal(signal *nethernet.Signal) error {
 	select {
 	case <-l.closed:
 		return net.ErrClosed
 	default:
+		networkID, err := strconv.ParseUint(signal.NetworkID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse network ID as uint64: %w", err)
+		}
+
 		l.addressesMu.RLock()
-		addr, ok := l.addresses[signal.NetworkID]
+		addr, ok := l.addresses[networkID]
 		l.addressesMu.RUnlock()
 
 		if !ok {
-			return fmt.Errorf("no address found for network ID: %d", signal.NetworkID)
+			return fmt.Errorf("no address found for network ID: %d", networkID)
 		}
 
-		_, err := l.write(Marshal(&MessagePacket{
-			RecipientID: signal.NetworkID,
+		_, err = l.conn.WriteTo(Marshal(&MessagePacket{
+			RecipientID: networkID,
 			Data:        signal.String(),
 		}, l.conf.NetworkID), addr.addr)
 		return err
 	}
 }
 
-func (l *Listener) Notify(n nethernet.Notifier) func() {
+// Notify registers the notifier on the Listener for notifying signals and returns
+// a function for stop notifying signals on the notifier.
+func (l *Listener) Notify(n nethernet.Notifier) (stop func()) {
 	l.notifiersMu.Lock()
 	i := l.notifyCount
 	l.notifiers[i] = n
@@ -148,12 +158,16 @@ func (l *Listener) Notify(n nethernet.Notifier) func() {
 	}
 }
 
+// stop stops notifying signals on the notifier with the corresponding ID. The ID
+// is internally assigned for the notifier and contained in the stop function returned
+// by [Listener.Notify]. It should not be called by anywhere else.
 func (l *Listener) stop(i uint32, n nethernet.Notifier) {
 	n.NotifyError(nethernet.ErrSignalingStopped)
 
 	delete(l.notifiers, i)
 }
 
+// Credentials returns a nil *nethernet.Credentials with a nil error if the Listener is not closed.
 func (l *Listener) Credentials(context.Context) (*nethernet.Credentials, error) {
 	select {
 	case <-l.closed:
@@ -163,16 +177,22 @@ func (l *Listener) Credentials(context.Context) (*nethernet.Credentials, error) 
 	}
 }
 
-func (l *Listener) NetworkID() uint64 {
-	return l.conf.NetworkID
+// NetworkID returns the numerical NetherNet network ID for the Listener in string form.
+func (l *Listener) NetworkID() string {
+	return strconv.FormatUint(l.conf.NetworkID, 10)
 }
 
+// Responses returns the responses sent from servers in the same network during LAN discovery
+// using RequestPacket with the broadcast address specified in [ListenConfig.BroadcastAddress].
 func (l *Listener) Responses() map[uint64][]byte {
 	l.responsesMu.Lock()
 	defer l.responsesMu.Unlock()
+	// As Listener.responses are continuously supposed to be written by Listener.background,
+	// we return a clone of the map.
 	return maps.Clone(l.responses)
 }
 
+// listen continuously reads packets received in the conn and calls handlePacket.
 func (l *Listener) listen() {
 	for {
 		b := make([]byte, 1024)
@@ -190,6 +210,8 @@ func (l *Listener) listen() {
 	}
 }
 
+// handlePacket handles a packet data received from the remote network. An addr will be mapped
+// for the NetherNet ID for future use in [NetherNet.Signal], if decoding was successful.
 func (l *Listener) handlePacket(data []byte, addr net.Addr) error {
 	pk, senderID, err := Unmarshal(data)
 	if err != nil {
@@ -208,6 +230,7 @@ func (l *Listener) handlePacket(data []byte, addr net.Addr) error {
 			addr:      addr,
 		}
 	}
+	// Update or set the timestamp for expiring them in deleteInactiveAddresses.
 	a.t = time.Now()
 	l.addresses[senderID] = a
 	l.addressesMu.Unlock()
@@ -226,12 +249,14 @@ func (l *Listener) handlePacket(data []byte, addr net.Addr) error {
 	return err
 }
 
+// handleRequest handles a RequestPacket broadcasted from the clients.
+// It responds with a ResponsePacket containing the pongData if it was non-nil.
 func (l *Listener) handleRequest(addr net.Addr) error {
 	data := l.pongData.Load()
 	if data == nil {
 		return errors.New("application data not set yet")
 	}
-	if _, err := l.write(Marshal(&ResponsePacket{
+	if _, err := l.conn.WriteTo(Marshal(&ResponsePacket{
 		ApplicationData: *data,
 	}, l.conf.NetworkID), addr); err != nil {
 		return fmt.Errorf("write response: %w", err)
@@ -239,6 +264,8 @@ func (l *Listener) handleRequest(addr net.Addr) error {
 	return nil
 }
 
+// handleResponse handles a ResponsePacket sent from the servers.
+// It stores its ApplicationData to the responses atomically.
 func (l *Listener) handleResponse(pk *ResponsePacket, senderID uint64) error {
 	l.responsesMu.Lock()
 	l.responses[senderID] = pk.ApplicationData
@@ -247,6 +274,8 @@ func (l *Listener) handleResponse(pk *ResponsePacket, senderID uint64) error {
 	return nil
 }
 
+// handleMessage handles a MessagePacket sent from the remote NetherNet network.
+// It discards the packet if the Data is "Ping", otherwise decodes them as a [nethernet.Signal].
 func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
 	if pk.Data == "Ping" {
 		return nil
@@ -256,7 +285,7 @@ func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
 	if err := signal.UnmarshalText([]byte(pk.Data)); err != nil {
 		return fmt.Errorf("decode signal: %w", err)
 	}
-	signal.NetworkID = senderID
+	signal.NetworkID = strconv.FormatUint(senderID, 10)
 
 	l.notifiersMu.Lock()
 	for _, n := range l.notifiers {
@@ -267,11 +296,16 @@ func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
 	return nil
 }
 
+// ServerData stores the ServerData for responding to the clients broadcasting
+// RequestPacket with a ResponsePacket containing the binary representation.
 func (l *Listener) ServerData(d *ServerData) {
 	b, _ := d.MarshalBinary()
 	l.pongData.Store(&b)
 }
 
+// PongData sets the application data contained in ResponsePacket in response
+// to clients broadcasting RequestPacket. It currently decodes the data as a
+// pong data from Minecraft listeners.
 func (l *Listener) PongData(b []byte) {
 	parts := strings.Split(string(b), ";")
 	if len(parts) < 9 {
@@ -281,7 +315,6 @@ func (l *Listener) PongData(b []byte) {
 	players, _ := strconv.Atoi(parts[4])
 	maxPlayers, _ := strconv.Atoi(parts[5])
 	d := &ServerData{
-		Version:        0x03,
 		ServerName:     parts[1],
 		LevelName:      parts[7],
 		GameType:       0, // TODO: Parse from parts[8] (survival, creative...)
@@ -294,6 +327,7 @@ func (l *Listener) PongData(b []byte) {
 	l.ServerData(d)
 }
 
+// Close closes the Listener. Any notifiers registered to the Listener will be stopped.
 func (l *Listener) Close() (err error) {
 	l.once.Do(func() {
 		err = l.conn.Close()
@@ -307,6 +341,8 @@ func (l *Listener) Close() (err error) {
 	return err
 }
 
+// background continuously broadcasts RequestPacket and calls deleteInactiveAddresses
+// at 2 seconds interval until the Listener closes.
 func (l *Listener) background() {
 	ticker := time.NewTicker(time.Second * 2)
 	defer ticker.Stop()
@@ -329,6 +365,8 @@ func (l *Listener) background() {
 	}
 }
 
+// deleteInactiveAddresses deletes inactive addresses mapped to NetherNet IDs. It specifically
+// removes if the address was not known for sending packets in the last 15 seconds.
 func (l *Listener) deleteInactiveAddresses() {
 	l.addressesMu.Lock()
 	maps.DeleteFunc(l.addresses, func(_ uint64, a address) bool {
@@ -337,33 +375,13 @@ func (l *Listener) deleteInactiveAddresses() {
 	l.addressesMu.Unlock()
 }
 
-func (l *Listener) write(b []byte, addr net.Addr) (n int, err error) {
-	if remote, ok := l.addrPort(addr); ok {
-		if local, ok := l.addrPort(l.conn.LocalAddr()); ok {
-			if remote.Addr().Compare(local.Addr()) == 0 {
-				bcast, err := broadcastAddress()
-				if err != nil {
-					l.conf.Log.Error("error resolving broadcast address", slog.Any("addr", addr), slog.Any("error", err))
-				} else {
-					addr = bcast
-				}
-			}
-		}
-	}
-	return l.conn.WriteTo(b, addr)
-}
-
-func (l *Listener) addrPort(addr net.Addr) (netip.AddrPort, bool) {
-	if a, ok := addr.(interface {
-		AddrPort() netip.AddrPort
-	}); ok {
-		return a.AddrPort(), true
-	}
-	return netip.AddrPort{}, false
-}
-
+// address encapsulates a mapping for NetherNet IDs and the UDP address responsible for sending
+// packets. It is used for signaling a NetherNet network with an ID in [Listener.Signal].
 type address struct {
+	// networkID is the NetherNet network ID in packets sent from the addr.
 	networkID uint64
-	t         time.Time
-	addr      net.Addr
+	// t is the last timestamp that the packet was received from the addr with networkID.
+	t time.Time
+	// addr is the UDP address known for sending packets with the networkID.
+	addr net.Addr
 }

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -50,6 +50,15 @@ func (conf ListenConfig) Listen(addr string) (*Listener, error) {
 		return nil, err
 	}
 
+	if conf.BroadcastAddress == nil && addrPort.Port() != DefaultPort {
+		// If the port for the address is 7551, it means no applications are listening on this network
+		// and server discovery using limited broadcast on net.IPv4bcast is not meaningful.
+		conf.BroadcastAddress = &net.UDPAddr{
+			IP:   net.IPv4bcast,
+			Port: DefaultPort,
+		}
+	}
+
 	l := &Listener{
 		conn: conn,
 
@@ -63,15 +72,6 @@ func (conf ListenConfig) Listen(addr string) (*Listener, error) {
 		closed: make(chan struct{}),
 	}
 	go l.listen()
-
-	if conf.BroadcastAddress == nil && addrPort.Port() != DefaultPort {
-		// If the port for the address is 7551, it means no applications are listening on this network
-		// and server discovery using limited broadcast on net.IPv4bcast is not meaningful.
-		conf.BroadcastAddress = &net.UDPAddr{
-			IP:   net.IPv4bcast,
-			Port: DefaultPort,
-		}
-	}
 	go l.background()
 
 	return l, nil

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -64,18 +64,22 @@ func (conf ListenConfig) Listen(addr string) (*Listener, error) {
 	}
 	go l.listen()
 
-	if conf.BroadcastAddress == nil && addrPort.Port() != 7551 {
+	if conf.BroadcastAddress == nil && addrPort.Port() != DefaultPort {
 		// If the port for the address is 7551, it means no applications are listening on this network
 		// and server discovery using limited broadcast on net.IPv4bcast is not meaningful.
 		conf.BroadcastAddress = &net.UDPAddr{
 			IP:   net.IPv4bcast,
-			Port: 7551,
+			Port: DefaultPort,
 		}
 	}
 	go l.background()
 
 	return l, nil
 }
+
+// DefaultPort is the port used for LAN discovery in Minecraft: Bedrock Edition.
+// Servers should listen on this port to receive RequestPacket broadcasted from clients.
+const DefaultPort = 7551
 
 // Listener represents a listener for LAN discovery. It uses UDP as the underlying protocol
 // and allows both discovering servers on the network using broadcast or announcing servers

--- a/discovery/listener_test.go
+++ b/discovery/listener_test.go
@@ -1,20 +1,156 @@
 package discovery
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
-	"github.com/df-mc/go-nethernet"
 	"log/slog"
 	"math/rand"
 	"net"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/df-mc/go-nethernet"
 )
+
+func TestDiscoveryListen(t *testing.T) {
+	networkID := rand.Uint64()
+	listener, err := net.ListenUDP("udp", &net.UDPAddr{
+		Port: 7551,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer listener.Close()
+
+	for {
+		buf := make([]byte, 1024)
+		n, addr, err := listener.ReadFromUDP(buf)
+		if err != nil {
+			panic(err)
+		}
+		b := buf[:n]
+		pk, senderID, err := Unmarshal(b)
+		if err != nil {
+			panic(err)
+		}
+		t.Logf("%#v %d %s", pk, senderID, addr)
+
+		if _, ok := pk.(*RequestPacket); ok {
+			data, _ := (&ServerData{
+				ServerName:     "df-mc/go-nethernet",
+				LevelName:      "Bedrock World",
+				GameType:       2,
+				PlayerCount:    1,
+				MaxPlayerCount: 8,
+				TransportLayer: 2, // NetherNet
+				ConnectionType: 4, // LAN
+			}).MarshalBinary()
+			resp := &ResponsePacket{
+				ApplicationData: data,
+			}
+			if _, err := listener.WriteToUDP(Marshal(resp, networkID), addr); err != nil {
+				t.Fatalf("error sending response: %s", err)
+			}
+			t.Logf("responded to Request packet")
+		} else if pk, ok := pk.(*MessagePacket); ok && pk.Data != "Ping" {
+			t.Log(pk.Data)
+		}
+	}
+}
+
+func TestDiscovery(t *testing.T) {
+	networkID := rand.Uint64()
+	request := Marshal(&RequestPacket{}, networkID)
+
+	listener, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		panic(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		t.Cleanup(ticker.Stop)
+
+		for range ticker.C {
+			if n, err := listener.WriteToUDP(request, &net.UDPAddr{
+				IP:   net.IPv4bcast,
+				Port: 7551,
+			}); err != nil {
+				panic(err)
+			} else {
+				if n != len(request) {
+					t.Fatalf("request is not fully sent: %d != %d", n, len(request))
+				}
+			}
+			t.Log("ping")
+		}
+	}()
+
+	for {
+		buf := make([]byte, 1024)
+		n, addr, err := listener.ReadFromUDP(buf)
+		if err != nil {
+			panic(err)
+		}
+		b := buf[:n]
+		pk, senderID, err := Unmarshal(b)
+		if err != nil {
+			panic(err)
+		}
+		t.Logf("%#v %d %s", pk, senderID, addr)
+
+		if pk, ok := pk.(*ResponsePacket); ok {
+			if false {
+				data := bytes.NewBuffer(pk.ApplicationData)
+
+				var v uint8
+				if err := binary.Read(data, binary.LittleEndian, &v); err != nil {
+					t.Fatalf("error reading version: %s", err)
+				} else if v != 4 {
+					t.Fatalf("version mismatch: %d != 4", v)
+				}
+				t.Logf("version: %d", v)
+
+				serverName, err := readBytes[uint8](data)
+				if err != nil {
+					t.Fatalf("error reading server name: %s", err)
+				}
+				t.Logf("server name: %q", serverName)
+
+				levelName, err := readBytes[uint8](data)
+				if err != nil {
+					t.Fatalf("error reading level name: %s", err)
+				}
+				t.Logf("level name: %q", levelName)
+
+				gameType, err := data.ReadByte()
+				if err != nil {
+					t.Fatalf("error reading game type: %s", err)
+				}
+				t.Logf("game type: %d", gameType)
+				// adventure: 4, survival: 0, creative: 2
+
+				// transport layer
+				// unknown (why is it 8)
+				t.Logf("%#v", data.Bytes())
+			}
+			data := &ServerData{}
+			if err := data.UnmarshalBinary(pk.ApplicationData); err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("%#v", data)
+		}
+	}
+}
 
 func TestListen(t *testing.T) {
 	cfg := ListenConfig{
 		NetworkID: rand.Uint64(),
 	}
-	d, err := cfg.Listen("udp", "0.0.0.0:7551")
+	d, err := cfg.Listen("0.0.0.0:7551")
 	if err != nil {
 		t.Fatalf("error listening on discovery: %s", err)
 	}
@@ -24,7 +160,6 @@ func TestListen(t *testing.T) {
 		}
 	})
 	d.ServerData(&ServerData{
-		Version:        0x3,
 		ServerName:     "df-mc/go-nethernet",
 		LevelName:      "Bedrock World",
 		GameType:       2,

--- a/discovery/listener_test.go
+++ b/discovery/listener_test.go
@@ -1,150 +1,15 @@
 package discovery
 
 import (
-	"bytes"
-	"encoding/binary"
 	"errors"
 	"log/slog"
 	"math/rand"
 	"net"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/df-mc/go-nethernet"
 )
-
-func TestDiscoveryListen(t *testing.T) {
-	networkID := rand.Uint64()
-	listener, err := net.ListenUDP("udp", &net.UDPAddr{
-		Port: 7551,
-	})
-	if err != nil {
-		panic(err)
-	}
-	defer listener.Close()
-
-	for {
-		buf := make([]byte, 1024)
-		n, addr, err := listener.ReadFromUDP(buf)
-		if err != nil {
-			panic(err)
-		}
-		b := buf[:n]
-		pk, senderID, err := Unmarshal(b)
-		if err != nil {
-			panic(err)
-		}
-		t.Logf("%#v %d %s", pk, senderID, addr)
-
-		if _, ok := pk.(*RequestPacket); ok {
-			data, _ := (&ServerData{
-				ServerName:     "df-mc/go-nethernet",
-				LevelName:      "Bedrock World",
-				GameType:       2,
-				PlayerCount:    1,
-				MaxPlayerCount: 8,
-				TransportLayer: 2, // NetherNet
-				ConnectionType: 4, // LAN
-			}).MarshalBinary()
-			resp := &ResponsePacket{
-				ApplicationData: data,
-			}
-			if _, err := listener.WriteToUDP(Marshal(resp, networkID), addr); err != nil {
-				t.Fatalf("error sending response: %s", err)
-			}
-			t.Logf("responded to Request packet")
-		} else if pk, ok := pk.(*MessagePacket); ok && pk.Data != "Ping" {
-			t.Log(pk.Data)
-		}
-	}
-}
-
-func TestDiscovery(t *testing.T) {
-	networkID := rand.Uint64()
-	request := Marshal(&RequestPacket{}, networkID)
-
-	listener, err := net.ListenUDP("udp", nil)
-	if err != nil {
-		panic(err)
-	}
-	defer listener.Close()
-
-	go func() {
-		ticker := time.NewTicker(time.Second)
-		t.Cleanup(ticker.Stop)
-
-		for range ticker.C {
-			if n, err := listener.WriteToUDP(request, &net.UDPAddr{
-				IP:   net.IPv4bcast,
-				Port: 7551,
-			}); err != nil {
-				panic(err)
-			} else {
-				if n != len(request) {
-					t.Fatalf("request is not fully sent: %d != %d", n, len(request))
-				}
-			}
-			t.Log("ping")
-		}
-	}()
-
-	for {
-		buf := make([]byte, 1024)
-		n, addr, err := listener.ReadFromUDP(buf)
-		if err != nil {
-			panic(err)
-		}
-		b := buf[:n]
-		pk, senderID, err := Unmarshal(b)
-		if err != nil {
-			panic(err)
-		}
-		t.Logf("%#v %d %s", pk, senderID, addr)
-
-		if pk, ok := pk.(*ResponsePacket); ok {
-			if false {
-				data := bytes.NewBuffer(pk.ApplicationData)
-
-				var v uint8
-				if err := binary.Read(data, binary.LittleEndian, &v); err != nil {
-					t.Fatalf("error reading version: %s", err)
-				} else if v != 4 {
-					t.Fatalf("version mismatch: %d != 4", v)
-				}
-				t.Logf("version: %d", v)
-
-				serverName, err := readBytes[uint8](data)
-				if err != nil {
-					t.Fatalf("error reading server name: %s", err)
-				}
-				t.Logf("server name: %q", serverName)
-
-				levelName, err := readBytes[uint8](data)
-				if err != nil {
-					t.Fatalf("error reading level name: %s", err)
-				}
-				t.Logf("level name: %q", levelName)
-
-				gameType, err := data.ReadByte()
-				if err != nil {
-					t.Fatalf("error reading game type: %s", err)
-				}
-				t.Logf("game type: %d", gameType)
-				// adventure: 4, survival: 0, creative: 2
-
-				// transport layer
-				// unknown (why is it 8)
-				t.Logf("%#v", data.Bytes())
-			}
-			data := &ServerData{}
-			if err := data.UnmarshalBinary(pk.ApplicationData); err != nil {
-				t.Fatal(err)
-			}
-			t.Logf("%#v", data)
-		}
-	}
-}
 
 func TestListen(t *testing.T) {
 	cfg := ListenConfig{

--- a/discovery/listener_test.go
+++ b/discovery/listener_test.go
@@ -166,6 +166,7 @@ func TestListen(t *testing.T) {
 		PlayerCount:    1,
 		MaxPlayerCount: 8,
 		TransportLayer: 2,
+		ConnectionType: 4,
 	})
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -58,7 +58,7 @@ func Unmarshal(b []byte) (Packet, uint64, error) {
 
 	hash := hmac.New(sha256.New, key[:])
 	hash.Write(payload)
-	if checksum := hash.Sum(nil); bytes.Compare(b[:32], checksum) != 0 {
+	if checksum := hash.Sum(nil); !bytes.Equal(b[:32], checksum) {
 		return nil, 0, fmt.Errorf("checksum mismatch: %x != %x", b[:32], checksum)
 	}
 	buf := bytes.NewBuffer(payload)

--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -114,11 +114,8 @@ func writeBytes[L ~uint32 | ~uint8](w io.Writer, b []byte) {
 }
 
 const (
-	// IDRequestPacket is the packet ID for RequestPacket.
 	IDRequestPacket uint16 = iota
-	// IDResponsePacket is the packet ID for ResponsePacket.
 	IDResponsePacket
-	// IDMessagePacket is the packet ID for MessagePacket.
 	IDMessagePacket
 )
 

--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -9,13 +9,19 @@ import (
 	"io"
 )
 
+// Packet describes a packet used in LAN discovery.
 type Packet interface {
+	// ID uniquely returns the ID of the packet. It is one of the first byte
+	// in the Header and used to identify which packet to decode in [Unmarshal].
 	ID() uint16
 
+	// Read reads/decodes the packet data from the [io.Reader].
 	Read(r io.Reader) error
+	// Write writes the packet data into the [io.Writer].
 	Write(w io.Writer)
 }
 
+// Marshal encodes the packet into the bytes with using the sender ID.
 func Marshal(pk Packet, senderID uint64) []byte {
 	buf := &bytes.Buffer{}
 
@@ -39,6 +45,8 @@ func Marshal(pk Packet, senderID uint64) []byte {
 	return b
 }
 
+// Unmarshal decodes the packet from the bytes and returns them with an ID of the sender
+// which has sent the packet. An error may be returned during decoding the content.
 func Unmarshal(b []byte) (Packet, uint64, error) {
 	if len(b) < 32 {
 		return nil, 0, io.ErrUnexpectedEOF
@@ -78,9 +86,13 @@ func Unmarshal(b []byte) (Packet, uint64, error) {
 	if err := pk.Read(buf); err != nil {
 		return nil, h.SenderID, err
 	}
+	if buf.Len() != 0 {
+		return nil, h.SenderID, fmt.Errorf("unread %d bytes", buf.Len())
+	}
 	return pk, h.SenderID, nil
 }
 
+// readBytes reads bytes from the [io.Reader] prefixed with a length for the generic type (uint32 or uint8).
 func readBytes[L ~uint32 | ~uint8](r io.Reader) ([]byte, error) {
 	var length L
 	if err := binary.Read(r, binary.LittleEndian, &length); err != nil {
@@ -95,22 +107,31 @@ func readBytes[L ~uint32 | ~uint8](r io.Reader) ([]byte, error) {
 	return b, nil
 }
 
+// writeBytes writes bytes into the [io.Writer] prefixed with a length for the generic type (uint32 or uint8).
 func writeBytes[L ~uint32 | ~uint8](w io.Writer, b []byte) {
 	_ = binary.Write(w, binary.LittleEndian, (L)(len(b)))
 	_, _ = w.Write(b)
 }
 
 const (
+	// IDRequestPacket is the packet ID for RequestPacket.
 	IDRequestPacket uint16 = iota
+	// IDResponsePacket is the packet ID for ResponsePacket.
 	IDResponsePacket
+	// IDMessagePacket is the packet ID for MessagePacket.
 	IDMessagePacket
 )
 
+// Header describes the binary structure of the initial bytes of a packet
+// transmitted during LAN discovery.
 type Header struct {
+	// PacketID is the ID of the packet.
 	PacketID uint16
+	// SenderID is the ID of the network that sent the packet.
 	SenderID uint64
 }
 
+// Read reads and decodes the Header from the [io.Reader].
 func (h *Header) Read(r io.Reader) error {
 	if err := binary.Read(r, binary.LittleEndian, &h.PacketID); err != nil {
 		return fmt.Errorf("read packet ID: %w", err)
@@ -127,6 +148,7 @@ func (h *Header) Read(r io.Reader) error {
 	return nil
 }
 
+// Write writes the binary structure of Header into the [io.Writer].
 func (h *Header) Write(w io.Writer) {
 	_ = binary.Write(w, binary.LittleEndian, h.PacketID)
 	_ = binary.Write(w, binary.LittleEndian, h.SenderID)

--- a/discovery/packet_message.go
+++ b/discovery/packet_message.go
@@ -6,13 +6,20 @@ import (
 	"io"
 )
 
+// MessagePacket is sent by both server and client to negotiate a NetherNet connection.
 type MessagePacket struct {
+	// RecipientID is the ID of NetherNet network that has sent the packet. Note that
+	// this is not connection ID, which is included in the Data and only used once in
+	// negotiation while network ID may be used across many connections.
 	RecipientID uint64
-	Data        string
+	// Data is the actual data for signaling. It contains the string form of nethernet.Signal.
+	Data string
 }
 
+// ID ...
 func (*MessagePacket) ID() uint16 { return IDMessagePacket }
 
+// Read ...
 func (pk *MessagePacket) Read(r io.Reader) error {
 	if err := binary.Read(r, binary.LittleEndian, &pk.RecipientID); err != nil {
 		return fmt.Errorf("read recipient ID: %w", err)
@@ -25,6 +32,7 @@ func (pk *MessagePacket) Read(r io.Reader) error {
 	return nil
 }
 
+// Write ...
 func (pk *MessagePacket) Write(w io.Writer) {
 	_ = binary.Write(w, binary.LittleEndian, pk.RecipientID)
 	writeBytes[uint32](w, []byte(pk.Data))

--- a/discovery/packet_message.go
+++ b/discovery/packet_message.go
@@ -8,9 +8,9 @@ import (
 
 // MessagePacket is sent by both server and client to negotiate a NetherNet connection.
 type MessagePacket struct {
-	// RecipientID is the ID of NetherNet network that has sent the packet. Note that
-	// this is not connection ID, which is included in the Data and only used once in
-	// negotiation while network ID may be used across many connections.
+	// RecipientID is the network ID to be signaled by MessagePacket. Note that this is
+	// not the connection ID. The connection ID is included in the Data field and used only
+	// during a single negotiation, whereas the network ID may be used across multiple connections.
 	RecipientID uint64
 	// Data is the actual data for signaling. It contains the string form of nethernet.Signal.
 	Data string

--- a/discovery/packet_request.go
+++ b/discovery/packet_request.go
@@ -2,10 +2,16 @@ package discovery
 
 import "io"
 
+// RequestPacket is sent by clients to discover servers on the same network using the
+// broadcast address on port 7551. Servers listen on the same port and respond with a
+// ResponsePacket containing basic information about their world.
 type RequestPacket struct{}
 
+// ID ...
 func (*RequestPacket) ID() uint16 { return IDRequestPacket }
 
+// Read ...
 func (*RequestPacket) Read(io.Reader) error { return nil }
 
+// Write ...
 func (*RequestPacket) Write(io.Writer) {}

--- a/discovery/packet_response.go
+++ b/discovery/packet_response.go
@@ -6,12 +6,17 @@ import (
 	"io"
 )
 
+// ResponsePacket is a packet sent by servers in response to a RequestPacket from clients to advertise the world.
 type ResponsePacket struct {
+	// ApplicationData contains application-specific data for the packet. In Minecraft: Bedrock Edition, it is
+	// typically structured as ServerData.
 	ApplicationData []byte
 }
 
+// ID ...
 func (*ResponsePacket) ID() uint16 { return IDResponsePacket }
 
+// Read ...
 func (pk *ResponsePacket) Read(r io.Reader) error {
 	data, err := readBytes[uint32](r)
 	if err != nil {
@@ -25,6 +30,7 @@ func (pk *ResponsePacket) Read(r io.Reader) error {
 	return nil
 }
 
+// Write ...
 func (pk *ResponsePacket) Write(w io.Writer) {
 	data := make([]byte, hex.EncodedLen(len(pk.ApplicationData)))
 	hex.Encode(data, pk.ApplicationData)

--- a/discovery/server_data.go
+++ b/discovery/server_data.go
@@ -18,7 +18,7 @@ type ServerData struct {
 	// GameType is the default game mode of the world. Players receive this game mode when they
 	// join. It remains unchanged during gameplay and may be updated the next time the world is hosted.
 	GameType uint8
-	// PlayerCount is teh amount of players currently connected to the world. Worlds
+	// PlayerCount is the amount of players currently connected to the world. Worlds
 	// with a player count of 0 or less are not displayed by clients, so it should at
 	// least 1 even if the server reports 0 to prevent world cards not appearing for the server.
 	PlayerCount int32

--- a/discovery/server_data.go
+++ b/discovery/server_data.go
@@ -17,7 +17,7 @@ type ServerData struct {
 	LevelName string
 	// GameType is the default game mode of the world. Players receive this game mode when they
 	// join. It remains unchanged during gameplay and may be updated the next time the world is hosted.
-	GameType int
+	GameType uint8
 	// PlayerCount is teh amount of players currently connected to the world. Worlds
 	// with a player count of 0 or less are not displayed by clients, so it should at
 	// least 1 even if the server reports 0 to prevent world cards not appearing for the server.
@@ -48,7 +48,7 @@ func (d *ServerData) MarshalBinary() ([]byte, error) {
 	_ = binary.Write(buf, binary.LittleEndian, version)
 	writeBytes[uint8](buf, []byte(d.ServerName))
 	writeBytes[uint8](buf, []byte(d.LevelName))
-	_ = binary.Write(buf, binary.LittleEndian, uint8(d.GameType<<1))
+	_ = binary.Write(buf, binary.LittleEndian, d.GameType<<1)
 	_ = binary.Write(buf, binary.LittleEndian, d.PlayerCount)
 	_ = binary.Write(buf, binary.LittleEndian, d.MaxPlayerCount)
 	_ = binary.Write(buf, binary.LittleEndian, d.EditorWorld)
@@ -84,7 +84,7 @@ func (d *ServerData) UnmarshalBinary(data []byte) error {
 	if err := binary.Read(buf, binary.LittleEndian, &gameType); err != nil {
 		return fmt.Errorf("read game type: %w", err)
 	}
-	d.GameType = int(gameType >> 1)
+	d.GameType = gameType >> 1
 	if err := binary.Read(buf, binary.LittleEndian, &d.PlayerCount); err != nil {
 		return fmt.Errorf("read player count: %w", err)
 	}

--- a/discovery/server_data.go
+++ b/discovery/server_data.go
@@ -6,39 +6,69 @@ import (
 	"fmt"
 )
 
+// ServerData defines the binary structure representing worlds in Minecraft: Bedrock Edition.
+// It is encapsulated in [ResponsePacket.ApplicationData] and sent in response to [RequestPacket]
+// broadcasted by clients on port 7551.
 type ServerData struct {
-	Version        uint8
-	ServerName     string
-	LevelName      string
-	GameType       int32
-	PlayerCount    int32
+	// ServerName is the name of the server. It is typically the player name of the owner
+	// hosting the server and is displayed below the LevelName in the world card.
+	ServerName string
+	// LevelName identifies the name of the world and appears at the top of ServerName in the world card.
+	LevelName string
+	// GameType is the default game mode of the world. Players receive this game mode when they
+	// join. It remains unchanged during gameplay and may be updated the next time the world is hosted.
+	GameType int
+	// PlayerCount is teh amount of players currently connected to the world. Worlds
+	// with a player count of 0 or less are not displayed by clients, so it should at
+	// least 1 even if the server reports 0 to prevent world cards not appearing for the server.
+	PlayerCount int32
+	// MaxPlayerCount is the maximum amount of players allowed to join the world.
 	MaxPlayerCount int32
-	EditorWorld    bool
-	Hardcore       bool
-	TransportLayer int32
+	// EditorWorld is a value dictates if the world was created as a project in Editor Mode.
+	// When enabled, the server or world card is only visible to clients in Editor Mode.
+	EditorWorld bool
+	// Hardcore indicates that the world is in hardcore mode. When enabled, it is common to also set
+	// GameType to Survival (0) as well to reproduce expected behavior.
+	Hardcore bool
+	// TransportLayer indicates the transport layer used by the server. In vanilla, this is typically
+	// 2 for NetherNet. Other values are also supported but are currently not useful in LAN discovery
+	// as it only allows connections over NetherNet. Therefore, the purposes or usage of this field is
+	// currently unknown.
+	TransportLayer uint8
+	// ConnectionType indicates the connection type used alongside the transport layer.
+	// In vanilla, this is typically 4 for using LAN as a signaling for NetherNet.
+	// Other values are supported but are currently not useful in LAN discovery.
+	ConnectionType uint8
 }
 
+// MarshalBinary ...
 func (d *ServerData) MarshalBinary() ([]byte, error) {
 	buf := &bytes.Buffer{}
 
-	_ = binary.Write(buf, binary.LittleEndian, d.Version)
+	_ = binary.Write(buf, binary.LittleEndian, version)
 	writeBytes[uint8](buf, []byte(d.ServerName))
 	writeBytes[uint8](buf, []byte(d.LevelName))
-	_ = binary.Write(buf, binary.LittleEndian, d.GameType)
+	_ = binary.Write(buf, binary.LittleEndian, uint8(d.GameType<<1))
 	_ = binary.Write(buf, binary.LittleEndian, d.PlayerCount)
 	_ = binary.Write(buf, binary.LittleEndian, d.MaxPlayerCount)
 	_ = binary.Write(buf, binary.LittleEndian, d.EditorWorld)
 	_ = binary.Write(buf, binary.LittleEndian, d.Hardcore)
-	_ = binary.Write(buf, binary.LittleEndian, d.TransportLayer)
+	_ = binary.Write(buf, binary.LittleEndian, d.TransportLayer<<1)
+	_ = binary.Write(buf, binary.LittleEndian, d.ConnectionType<<1)
 
 	return buf.Bytes(), nil
 }
 
+// UnmarshalBinary ...
 func (d *ServerData) UnmarshalBinary(data []byte) error {
 	buf := bytes.NewBuffer(data)
 
-	if err := binary.Read(buf, binary.LittleEndian, &d.Version); err != nil {
-		return fmt.Errorf("read version: %w", err)
+	var v uint8
+	if err := binary.Read(buf, binary.LittleEndian, &v); err != nil {
+		return fmt.Errorf("read version: %s", err)
+	}
+	if v != version {
+		return fmt.Errorf("version mismatch: got %d, want %d", v, version)
 	}
 	serverName, err := readBytes[uint8](buf)
 	if err != nil {
@@ -50,9 +80,11 @@ func (d *ServerData) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("read level name: %w", err)
 	}
 	d.LevelName = string(levelName)
-	if err := binary.Read(buf, binary.LittleEndian, &d.GameType); err != nil {
+	var gameType uint8
+	if err := binary.Read(buf, binary.LittleEndian, &gameType); err != nil {
 		return fmt.Errorf("read game type: %w", err)
 	}
+	d.GameType = int(gameType >> 1)
 	if err := binary.Read(buf, binary.LittleEndian, &d.PlayerCount); err != nil {
 		return fmt.Errorf("read player count: %w", err)
 	}
@@ -65,9 +97,22 @@ func (d *ServerData) UnmarshalBinary(data []byte) error {
 	if err := binary.Read(buf, binary.LittleEndian, &d.Hardcore); err != nil {
 		return fmt.Errorf("read hardcore: %w", err)
 	}
-	if err := binary.Read(buf, binary.LittleEndian, &d.TransportLayer); err != nil {
+	var transportLayer uint8
+	if err := binary.Read(buf, binary.LittleEndian, &transportLayer); err != nil {
 		return fmt.Errorf("read transport layer: %w", err)
+	}
+	d.TransportLayer = transportLayer >> 1
+	var connectionType uint8
+	if err := binary.Read(buf, binary.LittleEndian, &connectionType); err != nil {
+		return fmt.Errorf("read unknown: %w", err)
+	}
+	d.ConnectionType = connectionType >> 1
+	if length := buf.Len(); length != 0 {
+		return fmt.Errorf("unread %d bytes", length)
 	}
 
 	return nil
 }
+
+// version is the current version of ServerData as supported by the `discovery` package.
+const version uint8 = 4

--- a/internal/attr.go
+++ b/internal/attr.go
@@ -1,0 +1,7 @@
+package internal
+
+import "log/slog"
+
+const errorKey = "error"
+
+func ErrAttr(err error) slog.Attr { return slog.Any(errorKey, err) }

--- a/internal/attr.go
+++ b/internal/attr.go
@@ -1,7 +1,0 @@
-package internal
-
-import "log/slog"
-
-const errorKey = "error"
-
-func ErrAttr(err error) slog.Attr { return slog.Any(errorKey, err) }

--- a/listener.go
+++ b/listener.go
@@ -77,7 +77,10 @@ type Listener struct {
 
 	signaling Signaling
 	networkID string
-	id        uint64 // used for identifying Listener with an uint64.
+	// id is an uint64 representation of the networkID.
+	// When the networkID can be parsed as an uint64, it will be directly used.
+	// Otherwise, a random value will be generated.
+	id uint64
 
 	connections sync.Map
 

--- a/listener.go
+++ b/listener.go
@@ -196,10 +196,11 @@ func (l listenerNotifier) NotifySignal(signal *Signal) {
 // NotifyError notifies the Listener of an error that occurred in the Signaling implementation.
 // If the error is [ErrSignalingStopped], it will also close the Listener.
 func (l listenerNotifier) NotifyError(err error) {
-	l.conf.Log.Error("notified error in signaling", slog.Any("error", err))
 	if errors.Is(err, ErrSignalingStopped) {
 		_ = l.Close()
+		return
 	}
+	l.conf.Log.Error("notified error in signaling", slog.Any("error", err))
 }
 
 // handleOffer handles an incoming Signal of SignalTypeOffer. It parses the data of Signal into [sdp.SessionDescription]

--- a/listener.go
+++ b/listener.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/pion/sdp/v3"
-	"github.com/pion/webrtc/v4"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pion/sdp/v3"
+	"github.com/pion/webrtc/v4"
 )
 
 // ListenConfig encapsulates options for creating a new Listener through [ListenConfig.Listen].
@@ -50,10 +52,16 @@ func (conf ListenConfig) Listen(signaling Signaling) (*Listener, error) {
 	if conf.API == nil {
 		conf.API = webrtc.NewAPI()
 	}
+	networkID := signaling.NetworkID()
+	id, err := strconv.ParseUint(networkID, 10, 64)
+	if err != nil {
+		id = rand.Uint64()
+	}
 	l := &Listener{
 		conf:      conf,
 		signaling: signaling,
-		networkID: signaling.NetworkID(),
+		networkID: networkID,
+		id:        id,
 
 		incoming: make(chan *Conn),
 
@@ -68,7 +76,8 @@ type Listener struct {
 	conf ListenConfig
 
 	signaling Signaling
-	networkID uint64
+	networkID string
+	id        uint64 // used for identifying Listener with an uint64.
 
 	connections sync.Map
 
@@ -105,7 +114,7 @@ type Addr struct {
 	ConnectionID uint64
 
 	// NetworkID is a unique ID for the NetherNet network.
-	NetworkID uint64
+	NetworkID string
 
 	// Candidates contains a list of ICE candidates. These candidates are either gathered locally or
 	// signaled from a remote connection. ICE candidates are used to determine the UDP/TCP addresses
@@ -122,7 +131,7 @@ type Addr struct {
 // String formats the Addr as a string.
 func (addr *Addr) String() string {
 	b := &strings.Builder{}
-	b.WriteString(strconv.FormatUint(addr.NetworkID, 10))
+	b.WriteString(addr.NetworkID)
 	b.WriteByte(' ')
 	if addr.ConnectionID != 0 {
 		b.WriteByte('(')
@@ -142,7 +151,7 @@ func (addr *Addr) String() string {
 func (addr *Addr) Network() string { return "nethernet" }
 
 // ID returns the network ID of Listener.
-func (l *Listener) ID() int64 { return int64(l.networkID) }
+func (l *Listener) ID() int64 { return int64(l.id) }
 
 // PongData is a stub.
 func (l *Listener) PongData(b []byte) {

--- a/signal.go
+++ b/signal.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/pion/webrtc/v4"
 	"strconv"
 	"strings"
+
+	"github.com/pion/webrtc/v4"
 )
 
 // Signaling implements an interface for sending and receiving Signals over a network.
@@ -28,7 +29,7 @@ type Signaling interface {
 
 	// NetworkID returns the local network ID of Signaling. It is used by Listener to obtain its local
 	// network ID.
-	NetworkID() uint64
+	NetworkID() string
 	// PongData sets the server data in the format of a RakNet pong response. It is used by the Listener
 	// to respond to a ping request in the correct format.
 	PongData(b []byte)
@@ -87,7 +88,7 @@ type Signal struct {
 	// NetworkID is the internal ID used by Signaling to reference a remote network and not
 	// included to the String representation to be signaled to the remote network. If sent by
 	// a server, it represents the sender ID. If sent by a client, it represents the recipient ID.
-	NetworkID uint64
+	NetworkID string
 }
 
 // MarshalText returns the bytes of a string representation returned from [Signal.String].


### PR DESCRIPTION
Added docs for all types and methods, cleaned up LAN discovery, and changed the type for network IDs to `string`.
`ServerData`  in `nethernet/discovery` was also updated to support `1.21.130`.