### PR TITLE
Fix many bugs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -381,8 +381,7 @@ func (conn *Conn) handleSignal(signal *Signal) error {
 		if err != nil {
 			return fmt.Errorf("parse error code: %w", err)
 		}
-		conn.close(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code))
-		if err := conn.Close(); err != nil {
+		if err := conn.close(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code)); err != nil {
 			return fmt.Errorf("close: %w", err)
 		}
 	default:

--- a/conn.go
+++ b/conn.go
@@ -95,6 +95,9 @@ func (conn *Conn) Read(b []byte) (n int, err error) {
 // received from the data channel responsible for the MessageReliability. An error may be
 // returned if the Conn has been closed by [Conn.Close].
 func (conn *Conn) Receive(r MessageReliability) ([]byte, error) {
+	if r >= messageReliabilityCapacity {
+		return nil, fmt.Errorf("invalid message reliability: %d", r)
+	}
 	select {
 	case <-conn.ctx.Done():
 		return nil, context.Cause(conn.ctx)
@@ -145,6 +148,9 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 	case <-conn.ctx.Done():
 		return 0, context.Cause(conn.ctx)
 	default:
+		if reliability >= messageReliabilityCapacity {
+			return 0, fmt.Errorf("invalid message reliability: %d", reliability)
+		}
 		if reliability == MessageReliabilityUnreliable && len(data) > maxMessageSize {
 			return 0, fmt.Errorf("data larger than %d (received: %d) cannot be sent over UnreliableDataChannel", maxMessageSize, len(data))
 		}

--- a/conn.go
+++ b/conn.go
@@ -248,7 +248,7 @@ func (conn *Conn) remoteAddr() *Addr {
 func (conn *Conn) close(cause error) (err error) {
 	conn.once.Do(func() {
 		if cause != nil {
-			conn.log.Error("connection is closing with a cause", slog.Any("cause", err))
+			conn.log.Debug("connection is closing with a cause", slog.Any("cause", cause))
 		}
 		conn.cancel(cause)
 		conn.negotiator.handleClose(conn)

--- a/conn.go
+++ b/conn.go
@@ -323,8 +323,14 @@ func (conn *Conn) handleTransports() {
 		}
 	})
 	conn.sctp.OnClose(func(err error) {
+		var e error
+		if err != nil {
+			e = fmt.Errorf("nethernet: SCTP transport closed: %w", err)
+		} else {
+			e = errors.New("nethernet: SCTP transport closed")
+		}
 		// This handler function itself is holding the lock, call Close in a goroutine to avoid deadlock.
-		go conn.close(fmt.Errorf("nethernet: SCTP transport closed: %w", err))
+		go conn.close(e)
 	})
 }
 

--- a/conn.go
+++ b/conn.go
@@ -71,8 +71,8 @@ type Conn struct {
 
 	// ctx is the background context associated with the Conn.
 	ctx context.Context
-	// cancel is the function used to cancel the ctx. It is called
-	// by close
+	// cancel is the function used to cancel the ctx with a cause.
+	// It is called by close and must not be called elsewhere.
 	cancel context.CancelCauseFunc
 }
 

--- a/conn.go
+++ b/conn.go
@@ -47,9 +47,10 @@ type Conn struct {
 	candidateReceived chan struct{}
 
 	// candidates includes all [webrtc.ICECandidate] signaled from the remote connection.
-	// New candidates are appended atomically to the slice.
-	candidates   []webrtc.ICECandidate
-	candidatesMu sync.Mutex // Guards candidates
+	// New candidates are appended atomically to the slice. It is guarded by candidatesMu.
+	candidates []webrtc.ICECandidate
+	// candidatesMu guards candidates from concurrent read-write access.
+	candidatesMu sync.Mutex
 
 	// negotiator is either Listener or Dialer that the Conn has been negotiated through.
 	negotiator negotiator

--- a/conn.go
+++ b/conn.go
@@ -1,6 +1,7 @@
 package nethernet
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -59,14 +60,20 @@ type Conn struct {
 	// that are expected to both open during negotiating a new Conn.
 	channels [messageReliabilityCapacity]*dataChannel
 
-	once   sync.Once     // Ensures closure occur only once
-	closed chan struct{} // Notifies that a Conn has been closed.
+	// once ensures that the Conn is closed only once.
+	once sync.Once
 
 	log *slog.Logger
 
 	local     Addr
 	id        uint64
 	networkID string
+
+	// ctx is the background context associated with the Conn.
+	ctx context.Context
+	// cancel is the function used to cancel the ctx. It is called
+	// by close
+	cancel context.CancelCauseFunc
 }
 
 // Read receives a message from the 'ReliableDataChannel'. The bytes of the message data are copied to
@@ -88,8 +95,8 @@ func (conn *Conn) Read(b []byte) (n int, err error) {
 // returned if the Conn has been closed by [Conn.Close].
 func (conn *Conn) Receive(r MessageReliability) ([]byte, error) {
 	select {
-	case <-conn.closed:
-		return nil, net.ErrClosed
+	case <-conn.ctx.Done():
+		return nil, context.Cause(conn.ctx)
 	case pk := <-conn.channels[r].packets:
 		return pk, nil
 	}
@@ -116,6 +123,13 @@ func (conn *Conn) DisableEncryption() bool {
 	return true
 }
 
+// Context returns the background context associated with the Conn.
+// The returned context is canceled when the Conn is no longer usable.
+// Its cancellation cause describes the reason the Conn was closed.
+func (conn *Conn) Context() context.Context {
+	return conn.ctx
+}
+
 // Write writes the data into the 'ReliableDataChannel'. If the data exceeds 10000 bytes, it is split into
 // multiple segments. An error may be returned while writing a segment or if the Conn has been closed by [Conn.Close].
 func (conn *Conn) Write(b []byte) (n int, err error) {
@@ -127,8 +141,8 @@ func (conn *Conn) Write(b []byte) (n int, err error) {
 // returned while writing one or more segments or the Conn has been closed by [Conn.Close].
 func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err error) {
 	select {
-	case <-conn.closed:
-		return 0, net.ErrClosed
+	case <-conn.ctx.Done():
+		return 0, context.Cause(conn.ctx)
 	default:
 		if reliability == MessageReliabilityUnreliable && len(data) > maxMessageSize {
 			return 0, fmt.Errorf("data larger than %d (received: %d) cannot be sent over UnreliableDataChannel", maxMessageSize, len(data))
@@ -228,17 +242,20 @@ func (conn *Conn) remoteAddr() *Addr {
 	}
 }
 
-// Close closes the 'ReliableDataChannel' and 'UnreliableDataChannel', then closes the SCTP, DTLS,
-// and ICE transports of the Conn. An error may be returned using [errors.Join], which contains
-// non-nil errors encountered during closure.
-func (conn *Conn) Close() (err error) {
+// close closes the data channels associated with reliability parameters, then closes each transport
+// of the Conn. It also cancels the background context with the provided cause so that may be returned
+// by current-blocking methods such as [Conn.Read].
+func (conn *Conn) close(cause error) (err error) {
 	conn.once.Do(func() {
-		close(conn.closed)
+		if cause != nil {
+			conn.log.Error("connection is closing with a cause", slog.Any("cause", err))
+		}
+		conn.cancel(cause)
 		conn.negotiator.handleClose(conn)
 
 		for r := range messageReliabilityCapacity {
-			if conn.channels[r] != nil {
-				err = errors.Join(err, conn.channels[r].Close())
+			if ch := conn.channels[r]; ch != nil {
+				err = errors.Join(err, ch.Close())
 			}
 		}
 
@@ -252,9 +269,16 @@ func (conn *Conn) Close() (err error) {
 	return err
 }
 
-// handleTransports handles incoming messages from the 'ReliableDataChannel' and ensures
-// closure of its two data channels, as well as ICE, DTLS, and SCTP transports when any of
-// them are closed by the remote connection.
+// Close closes the 'ReliableDataChannel' and 'UnreliableDataChannel', then closes the SCTP, DTLS,
+// and ICE transports of the Conn. An error may be returned using [errors.Join], which contains
+// non-nil errors encountered during closure.
+func (conn *Conn) Close() (err error) {
+	return conn.close(net.ErrClosed)
+}
+
+// handleTransports registers handlers for all underlying transports and data channels
+// associated with the Conn. It also ensures that the Conn is closed if an unrecoverable
+// error has occurred in any of the underlying transports and data channels.
 func (conn *Conn) handleTransports() {
 	for r := MessageReliability(0); r < messageReliabilityCapacity; r++ {
 		ch := conn.channels[r]
@@ -265,41 +289,42 @@ func (conn *Conn) handleTransports() {
 						slog.String("label", ch.Label()))
 					return
 				}
-				conn.log.Error("error handling remote message",
-					slog.String("label", ch.Label()),
-					slog.Any("error", err),
-				)
+				// Receiving an invalid or incomplete message is considered unrecoverable
+				// as segmented packets cannot be completed. Closing the connection also
+				// helps mitigate malformed or malicious input from a peer.
+				// The DataChannel invokes this callback while holding an internal lock,
+				// so the connection is closed in a goroutine to avoid deadlock.
+				go conn.close(fmt.Errorf("nethernet: handle message in %s: %w", ch.Label(), err))
 			}
 		})
 		ch.OnClose(func() {
-			_ = conn.Close()
+			_ = conn.close(fmt.Errorf("nethernet: data channel %q closed by remote peer", ch.Label()))
 		})
 	}
 
 	conn.sctp.OnDataChannelOpened(func(channel *webrtc.DataChannel) {
-		conn.log.Error("connection was not expected to open a data channel after connection it is fully established", slog.String("label", channel.Label()))
-		_ = conn.Close()
+		_ = conn.close(fmt.Errorf("nethernet: data channel %q was unexpectedly opened by remote peer after connection was established", channel.Label()))
 	})
 
 	conn.ice.OnConnectionStateChange(func(state webrtc.ICETransportState) {
 		switch state {
 		case webrtc.ICETransportStateClosed, webrtc.ICETransportStateDisconnected, webrtc.ICETransportStateFailed:
-			// This handler function itself is holding the lock, call Close in a goroutine.
-			go conn.Close() // We need to make sure that all transports has been closed
+			// This handler function itself is holding the lock, call Close in a goroutine to avoid deadlock.
+			go conn.close(fmt.Errorf("nethernet: ICE transport entered unrecoverable state: %s", state))
 		default:
 		}
 	})
 	conn.dtls.OnStateChange(func(state webrtc.DTLSTransportState) {
 		switch state {
 		case webrtc.DTLSTransportStateClosed, webrtc.DTLSTransportStateFailed:
-			// This handler function itself is holding the lock, call Close in a goroutine.
-			go conn.Close() // We need to make sure that all transports has been closed
+			// This handler function itself is holding the lock, call Close in a goroutine to avoid deadlock.
+			go conn.close(fmt.Errorf("nethernet: DTLS transport entered unrecoverable state: %s", state))
 		default:
 		}
 	})
 	conn.sctp.OnClose(func(err error) {
-		// This handler function itself is holding the lock, call Close in a goroutine.
-		go conn.Close() // We need to make sure that all transports has been closed
+		// This handler function itself is holding the lock, call Close in a goroutine to avoid deadlock.
+		go conn.close(fmt.Errorf("nethernet: SCTP transport closed: %w", err))
 	})
 }
 
@@ -349,7 +374,7 @@ func (conn *Conn) handleSignal(signal *Signal) error {
 		if err != nil {
 			return fmt.Errorf("parse error code: %w", err)
 		}
-		conn.log.Error("connection failed with error", slog.Uint64("code", code))
+		conn.close(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code))
 		if err := conn.Close(); err != nil {
 			return fmt.Errorf("close: %w", err)
 		}
@@ -520,7 +545,7 @@ func (desc description) connectionRole(role webrtc.DTLSRole) sdp.ConnectionRole 
 // negotiator (caller) must establish each transport after creating a Conn when a first ICE
 // candidate has been signaled from the remote connection.
 func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.SCTPTransport, id uint64, networkID string, local Addr, n negotiator) *Conn {
-	return &Conn{
+	c := &Conn{
 		ice:  ice,
 		dtls: dtls,
 		sctp: sctp,
@@ -528,8 +553,6 @@ func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.
 		candidateReceived: make(chan struct{}),
 
 		negotiator: n,
-
-		closed: make(chan struct{}),
 
 		log: n.log().With(slog.Group("connection",
 			slog.Uint64("id", id),
@@ -541,6 +564,8 @@ func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.
 		id:        id,
 		networkID: networkID,
 	}
+	c.ctx, c.cancel = context.WithCancelCause(context.Background())
+	return c
 }
 
 type negotiator interface {

--- a/dial.go
+++ b/dial.go
@@ -172,7 +172,7 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 						return nil, fmt.Errorf("parse offer: %w", err)
 					}
 
-					go d.handleConn(c.Context(), c, signals)
+					go d.handleConn(c, signals)
 
 					select {
 					case <-ctx.Done():
@@ -279,13 +279,10 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 }
 
 // handleConn handles incoming Signals signaled from the remote connection and calls Conn.handleSignal
-// to handle them within the Conn. The [context.Context] is used to return immediately when it has been
-// canceled or exceeded the deadline.
-func (d Dialer) handleConn(ctx context.Context, conn *Conn, signals <-chan *Signal) {
+// to handle them within the Conn. It returns when the Conn context is canceled.
+func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal) {
 	for {
 		select {
-		case <-ctx.Done():
-			return
 		case <-conn.ctx.Done():
 			return
 		case signal, ok := <-signals:

--- a/dial.go
+++ b/dial.go
@@ -286,7 +286,7 @@ func (d Dialer) handleConn(ctx context.Context, conn *Conn, signals <-chan *Sign
 		select {
 		case <-ctx.Done():
 			return
-		case <-conn.closed:
+		case <-conn.ctx.Done():
 			return
 		case signal, ok := <-signals:
 			if !ok {

--- a/discovery/crypto.go
+++ b/discovery/crypto.go
@@ -30,6 +30,9 @@ func decrypt(src []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("make block: %w", err)
 	}
+	if len(src) == 0 || len(src)%block.BlockSize() != 0 {
+		return nil, fmt.Errorf("invalid ciphertext length: %d", len(src))
+	}
 	mode := ecb.NewECBDecrypter(block)
 	dst := make([]byte, len(src))
 	mode.CryptBlocks(dst, src)

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -339,6 +339,9 @@ func (l *Listener) handleResponse(pk *ResponsePacket, senderID uint64) error {
 // handleMessage handles a MessagePacket sent from the remote NetherNet network.
 // It discards the packet if the Data is "Ping", otherwise decodes them as a [nethernet.Signal].
 func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
+	if pk.RecipientID != l.conf.NetworkID {
+		return nil
+	}
 	if pk.Data == "Ping" {
 		return nil
 	}

--- a/listener.go
+++ b/listener.go
@@ -83,7 +83,8 @@ type Listener struct {
 
 	signaling Signaling
 	networkID string
-	id        uint64 // used for identifying Listener with an uint64.
+	// id is the numerical identifier for the Listener.
+	id uint64
 
 	connections sync.Map
 

--- a/listener.go
+++ b/listener.go
@@ -415,7 +415,7 @@ func (l *Listener) handleConn(conn *Conn, d *description) {
 		err = ctx.Err()
 	case <-l.closed:
 		err = net.ErrClosed
-	case <-conn.closed:
+	case <-conn.ctx.Done():
 		return
 	case <-conn.candidateReceived:
 		conn.log.Debug("received first candidate")

--- a/message.go
+++ b/message.go
@@ -154,7 +154,7 @@ func (c *dataChannel) handleMessage(b []byte) error {
 		return fmt.Errorf("parse: %w", err)
 	}
 
-	if c.reliability == MessageReliabilityUnreliable && msg.segments > 1 {
+	if c.reliability == MessageReliabilityUnreliable && msg.segments > 0 {
 		return fmt.Errorf("unexpected segment count on UnreliableDataChannel: %d", msg.segments)
 	}
 


### PR DESCRIPTION
This was PR'd into lactyy's fork a few days ago and I've been using it in prod confirmed working


1. **Dialer signal lifecycle fix**  
- Changed `defer stop()` to `defer` only on error.
- Changed `go d.handleConn(...)` to use `c.Context()` instead of a short-lived dial context.
- Why: after a successful dial, we must keep receiving late `CANDIDATEADD`/`CONNECTERROR` signals. The previous version shut down notifier handling as soon as `DialContext` returned.

2. **Remote error close-path fix**  
- Replaced “call `conn.close(...)` and ignore result, then call `conn.Close()` again” with one checked `conn.close(...)`.
- Why: the old pattern could swallow real close errors due to `sync.Once` behavior on the second call.

3. **Discovery notifier deadlock/leak fix**  
- Added `stop chan struct{}` to notifier.
- Forwarder goroutine now `select`s on `n.stop` while reading and while sending to caller output channel.
- `stop(i)` now closes `n.stop` before closing `n.in`.
- Why: if caller stops reading, the forwarder could block forever on `n.out <- sig`; then `stop()` wouldn’t fully shut it down and output channel closure could hang.

4. **Connection creation/cleanup ordering fix**  
- Moved `newConn(...)` earlier in negotiation paths (before signaling answer/offer and candidates), with deferred close on failure (`if !established` / `if err != nil`).
- Why: signaling can fail *after* ICE/DTLS/SCTP are created; this guarantees those transports are cleaned up on early-return error paths instead of leaking.

5. **Unreliable segmentation validation fix**  
- Changed unreliable message guard from `msg.segments > 1` to `msg.segments > 0`.
- Why: `segments` is “remaining segments,” so any value `> 0` already means fragmented payload. The old check incorrectly allowed 2-part unreliable payloads (`segments == 1`).

Also it removes passing the ctx to d.handleConn because it was redundant, its already checked in that method with conn.ctx