### PR TITLE
Be more lenient when connecting to nethernet servers with unexpected encoding

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -347,7 +347,6 @@ func (conn *Conn) handleSignal(signal *Signal) error {
 	case SignalTypeCandidate:
 		s := strings.TrimSpace(signal.Data)
 		s = strings.TrimPrefix(s, "a=")
-		s = strings.TrimPrefix(s, "candidate:")
 		candidate, err := ice.UnmarshalCandidate(s)
 
 		if err != nil {

--- a/conn.go
+++ b/conn.go
@@ -345,7 +345,11 @@ func (conn *Conn) handleTransports() {
 func (conn *Conn) handleSignal(signal *Signal) error {
 	switch signal.Type {
 	case SignalTypeCandidate:
-		candidate, err := ice.UnmarshalCandidate(signal.Data)
+		s := strings.TrimSpace(signal.Data)
+		s = strings.TrimPrefix(s, "a=")
+		s = strings.TrimPrefix(s, "candidate:")
+		candidate, err := ice.UnmarshalCandidate(s)
+
 		if err != nil {
 			return fmt.Errorf("decode candidate: %w", err)
 		}
@@ -416,7 +420,10 @@ func parseDescription(d *sdp.SessionDescription) (*description, error) {
 
 	attr, ok := m.Attribute("fingerprint")
 	if !ok {
-		return nil, errors.New("missing fingerprint attribute")
+		attr, ok = d.Attribute("fingerprint")
+		if !ok {
+			return nil, errors.New("missing fingerprint attribute")
+		}
 	}
 	fingerprint := strings.Split(attr, " ")
 	if len(fingerprint) != 2 {


### PR DESCRIPTION
Fingerprint being in descriptions:
```go
&sdp.SessionDescription{Version:0, Origin:sdp.Origin{Username:"rtc", SessionID:0x197ae519, SessionVersion:0x0, NetworkType:"IN", AddressType:"IP4", UnicastAddress:"127.0.0.1"}, SessionName:"-", SessionInformation:(*sdp.Information)(nil), URI:(*url.URL)(nil), EmailAddress:(*sdp.EmailAddress)(nil), PhoneNumber:(*sdp.PhoneNumber)(nil), ConnectionInformation:(*sdp.ConnectionInformation)(nil), Bandwidth:[]sdp.Bandwidth(nil), TimeDescriptions:[]sdp.TimeDescription{sdp.TimeDescription{Timing:sdp.Timing{StartTime:0x0, StopTime:0x0}, RepeatTimes:[]sdp.RepeatTime(nil)}}, TimeZones:[]sdp.TimeZone(nil), EncryptionKey:(*sdp.EncryptionKey)(nil), Attributes:[]sdp.Attribute{sdp.Attribute{Key:"group", Value:"BUNDLE 0"}, sdp.Attribute{Key:"msid-semantic", Value:"WMS *"}, sdp.Attribute{Key:"ice-options", Value:"ice2,trickle"}, sdp.Attribute{Key:"fingerprint", Value:"sha-256 1D:E2:3C:CB:BC:0D:91:8A:B4:80:79:01:E2:45:3C:F2:B5:A1:77:8E:05:E8:EA:BA:DE:0D:FD:57:98:A1:8A:BA"}}, MediaDescriptions:[]*sdp.MediaDescription{(*sdp.MediaDescription)(0xc000306aa0)}}
```
Triming `a=` and `candidate:`:
```
time=2026-03-09T18:11:00.832-03:00 level=ERROR msg="error handling signal" src=dialer src=dialer connection.id=17881749345788948183 connection.networkID=17054195855071089586 error="decode candidate: failed to parse foundation: invalid ice-char token: = in a=candidate:1 1 UDP 2122317823 149.28.18.127 40880 typ host"
time=2026-03-09T18:11:01.106-03:00 level=ERROR msg="error handling signal" src=dialer src=dialer connection.id=17881749345788948183 connection.networkID=17054195855071089586 error="decode candidate: failed to parse foundation: invalid ice-char token: = in a=candidate:2 1 UDP 2122317567 172.18.0.1 40880 typ host"
time=2026-03-09T18:11:01.381-03:00 level=ERROR msg="error handling signal" src=dialer src=dialer connection.id=17881749345788948183 connection.networkID=17054195855071089586 error="decode candidate: failed to parse foundation: invalid ice-char token: = in a=candidate:3 1 UDP 2122317311 172.19.0.1 40880 typ host"
time=2026-03-09T18:11:01.655-03:00 level=ERROR msg="error handling signal" src=dialer src=dialer connection.id=17881749345788948183 connection.networkID=17054195855071089586 error="decode candidate: failed to parse foundation: invalid ice-char token: = in a=candidate:4 1 UDP 1686109439 149.28.18.127 40880 typ srflx raddr 0.0.0.0 rport 0"
```