### PR TITLE
Implement Trickle ICE

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -545,13 +545,16 @@ func (conn *Conn) gatherCandidates(signaling Signaling) error {
 			Data:         formatICECandidate(int(candidateIndex.Add(1)), *candidate, conn.description.ice),
 			NetworkID:    conn.networkID,
 		}); err != nil {
-			if err := signaling.Signal(conn.Context(), &Signal{
+			errCtx, cancel := context.WithTimeout(conn.Context(), time.Second*15)
+			defer cancel()
+
+			// I don't think the error code will be signaled back to the remote connection, but just in case.
+			if err := signaling.Signal(errCtx, &Signal{
 				Type:         SignalTypeError,
 				ConnectionID: conn.id,
 				Data:         strconv.Itoa(ErrorCodeSignalingFailedToSend),
 				NetworkID:    conn.networkID,
 			}); err != nil {
-				// I don't think the error code will be signaled back to the remote connection, but just in case.
 				conn.log.Error("error signaling error", slog.Any("error", err))
 			}
 			// This handler function itself is invoked while holding an internal lock, so call close in a goroutine to avoid deadlock.

--- a/conn.go
+++ b/conn.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pion/ice/v4"
@@ -31,16 +32,21 @@ import (
 // A Conn may be established by dialing a remote network ID using [Dialer.DialContext] (and other aliases),
 // or by accepting connections from a Listener that listens on a local network.
 //
-// The Conn do not utilize [webrtc.PeerConnection] as it does not allow creating a [sdp.SessionDescription]
-// with custom.
+// Conn does not use [webrtc.PeerConnection], because it needs to build custom
+// [sdp.SessionDescription] values during negotiation.
 //
 // Once established and negotiated through either Dialer or Listener, Conn handles messages sent
 // over the 'ReliableDataChannel' (which may be read using Read or ReadPacket), and ensures closure
 // of its WebRTC transports to confirm that all transports within Conn are closed.
 type Conn struct {
-	ice  *webrtc.ICETransport
-	dtls *webrtc.DTLSTransport
-	sctp *webrtc.SCTPTransport
+	ice      *webrtc.ICETransport
+	dtls     *webrtc.DTLSTransport
+	sctp     *webrtc.SCTPTransport
+	gatherer *webrtc.ICEGatherer
+
+	// description is the local session description for the Conn.
+	// newConn builds it from the local parameters of each underlying transport.
+	description *description
 
 	// candidateReceived notifies that the first candidate is received from the other
 	// end, indicating that the Conn is ready to start its transports.
@@ -68,9 +74,11 @@ type Conn struct {
 
 	log *slog.Logger
 
-	local     Addr
-	id        uint64
-	networkID string
+	// id is the random ID assigned to this connection.
+	// It will appear in [Signal.ConnectionID].
+	id uint64
+	// networkID and localNetworkID are the IDs of the remote and local NetherNet networks.
+	networkID, localNetworkID string
 
 	// ctx is the background context associated with the Conn.
 	ctx context.Context
@@ -211,13 +219,19 @@ func (*Conn) SetWriteDeadline(time.Time) error {
 // LocalAddr returns an Addr that includes the local network ID of the Conn with locally-gathered
 // ICE candidates.
 func (conn *Conn) LocalAddr() net.Addr {
-	addr := conn.local
-	addr.ConnectionID = conn.id
+	addr := &Addr{
+		NetworkID:    conn.localNetworkID,
+		ConnectionID: conn.id,
+	}
 	pair, _ := conn.ice.GetSelectedCandidatePair()
 	if pair != nil {
 		addr.SelectedCandidate = pair.Local
 	}
-	return &addr
+	candidates, err := conn.gatherer.GetLocalCandidates()
+	if err == nil {
+		addr.Candidates = candidates
+	}
+	return addr
 }
 
 // RemoteAddr returns an Addr that includes the remote network ID of the Conn with remotely-signaled
@@ -268,6 +282,7 @@ func (conn *Conn) close(cause error) (err error) {
 			conn.sctp.Stop(),
 			conn.dtls.Stop(),
 			conn.ice.Stop(),
+			conn.gatherer.Close(),
 		)
 	})
 	return err
@@ -418,29 +433,6 @@ func (conn *Conn) addRemoteCandidate(candidate webrtc.ICECandidate) error {
 	return nil
 }
 
-// addRemoteCandidatesFromSDP extracts ICE candidates bundled as a=candidate
-// lines in the [sdp.SessionDescription] and adds them to the connection. Some
-// signaling implementations batch candidates into the SDP
-// offer or answer instead of sending separate CANDIDATEADD signals.
-func (conn *Conn) addRemoteCandidatesFromSDP(d *sdp.SessionDescription) error {
-	if len(d.MediaDescriptions) == 0 {
-		return nil
-	}
-	for _, attr := range append(d.Attributes, d.MediaDescriptions[0].Attributes...) {
-		if !attr.IsICECandidate() {
-			continue
-		}
-		candidate, err := parseRemoteCandidate(attr.Value)
-		if err != nil {
-			return err
-		}
-		if err := conn.addRemoteCandidate(candidate); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 const maxMessageSize = 10000
 
 // parseDescription parses a [sdp.SessionDescription] signaled from a remote connection.
@@ -485,8 +477,10 @@ func parseDescription(d *sdp.SessionDescription) (*description, error) {
 	switch attr {
 	case sdp.ConnectionRoleActive.String():
 		role = webrtc.DTLSRoleClient
-	case sdp.ConnectionRoleActpass.String():
+	case sdp.ConnectionRolePassive.String():
 		role = webrtc.DTLSRoleServer
+	case sdp.ConnectionRoleActpass.String():
+		role = webrtc.DTLSRoleAuto
 	default:
 		return nil, fmt.Errorf("invalid setup attribute: %s", attr)
 	}
@@ -498,6 +492,18 @@ func parseDescription(d *sdp.SessionDescription) (*description, error) {
 	maxMessageSize, err := strconv.ParseUint(attr, 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("parse max-message-size attribute as uint32: %w", err)
+	}
+
+	var candidates []webrtc.ICECandidate
+	for _, attr := range append(d.Attributes, m.Attributes...) {
+		if !attr.IsICECandidate() {
+			continue
+		}
+		candidate, err := parseRemoteCandidate(attr.Value)
+		if err != nil {
+			return nil, fmt.Errorf("parse remote candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
 	}
 
 	return &description{
@@ -517,20 +523,57 @@ func parseDescription(d *sdp.SessionDescription) (*description, error) {
 		sctp: webrtc.SCTPCapabilities{
 			MaxMessageSize: uint32(maxMessageSize),
 		},
+		candidates: candidates,
 	}, nil
+}
+
+// gatherCandidates starts gathering local candidates and signaling them to the
+// remote peer using the provided [Signaling] implementation.
+func (conn *Conn) gatherCandidates(signaling Signaling) error {
+	var candidateIndex atomic.Uint32
+	conn.gatherer.OnLocalCandidate(func(candidate *webrtc.ICECandidate) {
+		// ICEGatherer already tracks its internal state, so we don't need to check if the connection is closed.
+		if candidate == nil {
+			conn.log.Debug("completed gathering local candidates")
+			return
+		}
+		ctx, cancel := context.WithTimeout(conn.Context(), time.Second*15)
+		defer cancel()
+		if err := signaling.Signal(ctx, &Signal{
+			Type:         SignalTypeCandidate,
+			ConnectionID: conn.id,
+			Data:         formatICECandidate(int(candidateIndex.Add(1)), *candidate, conn.description.ice),
+			NetworkID:    conn.networkID,
+		}); err != nil {
+			conn.log.Error("error signaling candidate", slog.Any("error", err))
+			if err := signaling.Signal(conn.Context(), &Signal{
+				Type:         SignalTypeError,
+				ConnectionID: conn.id,
+				Data:         strconv.Itoa(ErrorCodeSignalingFailedToSend),
+				NetworkID:    conn.networkID,
+			}); err != nil {
+				// I don't think the error code will be signaled back to the remote connection, but just in case.
+				conn.log.Error("error signaling error", slog.Any("error", err))
+			}
+		}
+	})
+	return conn.gatherer.Gather()
 }
 
 // description contains parameters necessary for starting ICE, DTLS, and SCTP transport within a Conn.
 //
-// It may be created by parsing a [sdp.SessionDescription] signaled from a remote connection or filed
-// in to encode a local description.
+// It can be created either by parsing a remote [sdp.SessionDescription] or by
+// filling it with local transport parameters before encoding.
 //
-// A description may be parsed by a negotiator (Listener r Dialer) using parseDescription with a [sdp.SessionDescription]
-// parsed from a Signal of SignalTypeOffer or SignalTypeAnswer.
+// A negotiator (Listener or Dialer) uses parseDescription after decoding a
+// SignalTypeOffer or SignalTypeAnswer payload into an [sdp.SessionDescription].
 type description struct {
 	ice  webrtc.ICEParameters
 	dtls webrtc.DTLSParameters
 	sctp webrtc.SCTPCapabilities
+
+	// candidates are inline ICE candidates included as SDP attributes.
+	candidates []webrtc.ICECandidate
 }
 
 // encode transforms the description into a [sdp.SessionDescription] and encodes them using the [sdp.SessionDescription.Marshal]
@@ -583,6 +626,14 @@ func (desc description) encode() ([]byte, error) {
 	media.WithValueAttribute("sctp-port", "5000")
 	media.WithValueAttribute("max-message-size", strconv.FormatUint(uint64(desc.sctp.MaxMessageSize), 10))
 
+	// We don't populate ICE candidates in the SDP but just in case.
+	for _, candidate := range desc.candidates {
+		d.Attributes = append(d.Attributes, sdp.Attribute{
+			Key:   sdp.AttrKeyCandidate,
+			Value: candidate.String(),
+		})
+	}
+
 	return d.WithMedia(media).Marshal()
 }
 
@@ -591,24 +642,61 @@ func (desc description) encode() ([]byte, error) {
 // as a [sdp.Attribute] of 'setup'.
 func (desc description) connectionRole(role webrtc.DTLSRole) sdp.ConnectionRole {
 	switch role {
-	case webrtc.DTLSRoleServer:
-		return sdp.ConnectionRoleActpass
-	default:
+	case webrtc.DTLSRoleClient:
+		// The server will send ClientHello to the client.
 		return sdp.ConnectionRoleActive
+	case webrtc.DTLSRoleServer:
+		// The client will send ClientHello to the server.
+		return sdp.ConnectionRolePassive
+	default:
+		// The client asks the server to choose which role to initiate DTLS.
+		return sdp.ConnectionRoleActpass
 	}
 }
 
-// newConn creates a peer Conn from the ICE, DTLS and SCTP transport.
-// It also attaches callback handlers to each transport so the Conn
-// is closed when any underling transport closes or enters an
-// unrecoverable state.
-// The caller must register [SCTPTransport.OnDataChannel] handler
-// immediately using the returned Conn.
-func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.SCTPTransport, id uint64, networkID string, local Addr, n negotiator) *Conn {
+// newConn creates a peer Conn using the provided [webrtc.API].
+// It initiates the ICE, DTLS, and SCTP transports, and attaches callback
+// handlers so the Conn closes if any transport enters an unrecoverable state.
+//
+// The caller must register [SCTPTransport.OnDataChannel] immediately on
+// the returned Conn, then use [Conn.description] to signal an offer or
+// answer to the remote peer.
+func newConn(api *webrtc.API, credentials *Credentials, id uint64, networkID, localNetworkID string, n negotiator) (*Conn, error) {
+	gatherer, err := api.NewICEGatherer(gatherOptions(credentials))
+	if err != nil {
+		return nil, wrapSignalError(fmt.Errorf("create ICE gatherer: %w", err), ErrorCodeFailedToCreatePeerConnection)
+	}
+	iceTransport := api.NewICETransport(gatherer)
+	dtlsTransport, err := api.NewDTLSTransport(iceTransport, nil)
+	if err != nil {
+		return nil, wrapSignalError(fmt.Errorf("create DTLS transport: %w", err), ErrorCodeFailedToCreatePeerConnection)
+	}
+	sctpTransport := api.NewSCTPTransport(dtlsTransport)
+
+	iceParams, err := iceTransport.GetLocalParameters()
+	if err != nil {
+		return nil, wrapSignalError(fmt.Errorf("obtain local ICE parameters: %w", err), ErrorCodeFailedToCreateAnswer)
+	}
+	dtlsParams, err := dtlsTransport.GetLocalParameters()
+	if err != nil {
+		return nil, wrapSignalError(fmt.Errorf("obtain local DTLS parameters: %w", err), ErrorCodeFailedToCreateAnswer)
+	}
+	if len(dtlsParams.Fingerprints) == 0 {
+		return nil, wrapSignalError(errors.New("local DTLS parameters has no fingerprints"), ErrorCodeFailedToCreateAnswer)
+	}
+	sctpCapabilities := sctpTransport.GetCapabilities()
+
 	c := &Conn{
-		ice:  ice,
-		dtls: dtls,
-		sctp: sctp,
+		ice:      iceTransport,
+		dtls:     dtlsTransport,
+		sctp:     sctpTransport,
+		gatherer: gatherer,
+
+		description: &description{
+			ice:  iceParams,
+			dtls: dtlsParams,
+			sctp: sctpCapabilities,
+		},
 
 		candidateReceived: make(chan struct{}),
 
@@ -619,14 +707,13 @@ func newConn(ice *webrtc.ICETransport, dtls *webrtc.DTLSTransport, sctp *webrtc.
 			slog.String("networkID", networkID),
 		)),
 
-		local: local,
-
-		id:        id,
-		networkID: networkID,
+		id:             id,
+		networkID:      networkID,
+		localNetworkID: localNetworkID,
 	}
 	c.ctx, c.cancel = context.WithCancelCause(context.Background())
 	c.handleTransports()
-	return c
+	return c, nil
 }
 
 type negotiator interface {

--- a/conn.go
+++ b/conn.go
@@ -545,7 +545,6 @@ func (conn *Conn) gatherCandidates(signaling Signaling) error {
 			Data:         formatICECandidate(int(candidateIndex.Add(1)), *candidate, conn.description.ice),
 			NetworkID:    conn.networkID,
 		}); err != nil {
-			conn.log.Error("error signaling candidate", slog.Any("error", err))
 			if err := signaling.Signal(conn.Context(), &Signal{
 				Type:         SignalTypeError,
 				ConnectionID: conn.id,
@@ -555,6 +554,8 @@ func (conn *Conn) gatherCandidates(signaling Signaling) error {
 				// I don't think the error code will be signaled back to the remote connection, but just in case.
 				conn.log.Error("error signaling error", slog.Any("error", err))
 			}
+			// This handler function itself is invoked while holding an internal lock, so call close in a goroutine to avoid deadlock.
+			go conn.close(fmt.Errorf("signal candidate: %w", err))
 		}
 	})
 	return conn.gatherer.Gather()

--- a/dial.go
+++ b/dial.go
@@ -52,167 +52,114 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 	if err != nil {
 		return nil, fmt.Errorf("obtain credentials: %w", err)
 	}
-	gatherer, err := d.API.NewICEGatherer(gatherOptions(credentials))
-	if err != nil {
-		return nil, fmt.Errorf("create ICE gatherer: %w", err)
-	}
 
-	var (
-		candidates     []webrtc.ICECandidate
-		gatherFinished = make(chan struct{})
-	)
-	gatherer.OnLocalCandidate(func(candidate *webrtc.ICECandidate) {
-		if candidate == nil {
-			close(gatherFinished)
-			return
+	// Signals may be received very early when signaling an offer with local candidates.
+	signals, stop := d.notifySignals(networkID, signaling)
+	defer func() {
+		if err != nil {
+			stop()
 		}
-		candidates = append(candidates, *candidate)
+	}()
+	c, err := newConn(d.API, credentials, d.ConnectionID, networkID, signaling.NetworkID(), dialerConn{
+		Dialer: d,
+		stop:   stop,
 	})
-	if err := gatherer.Gather(); err != nil {
-		return nil, fmt.Errorf("gather local candidates: %w", err)
+	if err != nil {
+		return nil, fmt.Errorf("create conn: %w", err)
 	}
-	select {
-	case <-ctx.Done():
-		_ = gatherer.Close()
-		return nil, ctx.Err()
-	case <-gatherFinished:
-		ice := d.API.NewICETransport(gatherer)
-		dtls, err := d.API.NewDTLSTransport(ice, nil)
+	defer func() {
 		if err != nil {
-			return nil, fmt.Errorf("create DTLS transport: %w", err)
+			_ = c.close(fmt.Errorf("dial failure: %w", err))
 		}
-		sctp := d.API.NewSCTPTransport(dtls)
+	}()
+	c.sctp.OnDataChannel(func(channel *webrtc.DataChannel) {
+		// For client connections, the server should never open a data channel.
+		//
+		// This handler function itself is invoked while holding an internal lock, so call close in a goroutine to avoid deadlock.
+		go c.close(fmt.Errorf("data channel %q was unexpectedly opened by remote peer", channel.Label()))
+	})
 
-		iceParams, err := ice.GetLocalParameters()
-		if err != nil {
-			return nil, fmt.Errorf("obtain local ICE parameters: %w", err)
-		}
-		dtlsParams, err := dtls.GetLocalParameters()
-		if err != nil {
-			return nil, fmt.Errorf("obtain local DTLS parameters: %w", err)
-		}
-		if len(dtlsParams.Fingerprints) == 0 {
-			return nil, errors.New("local DTLS parameters has no fingerprints")
-		}
-		sctpCapabilities := sctp.GetCapabilities()
+	// Encode an offer using the local parameters!
+	offer, err := c.description.encode()
+	if err != nil {
+		return nil, fmt.Errorf("encode offer: %w", err)
+	}
+	if err := signaling.Signal(ctx, &Signal{
+		Type:         SignalTypeOffer,
+		Data:         string(offer),
+		ConnectionID: d.ConnectionID,
+		NetworkID:    networkID,
+	}); err != nil {
+		return nil, fmt.Errorf("signal offer: %w", err)
+	}
 
-		// Signals may be received very early when signaling an offer with local candidates.
-		signals, stop := d.notifySignals(networkID, signaling)
-		defer func() {
-			if err != nil {
-				stop()
+	if err := c.gatherCandidates(signaling); err != nil {
+		return nil, fmt.Errorf("gather candidates: %w", err)
+	}
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return nil, context.Cause(c.ctx)
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				d.signalError(signaling, networkID, ErrorCodeNegotiationTimeoutWaitingForResponse)
 			}
-		}()
-		c := newConn(ice, dtls, sctp, d.ConnectionID, networkID, Addr{
-			NetworkID:    signaling.NetworkID(),
-			ConnectionID: d.ConnectionID,
-			Candidates:   candidates,
-		}, dialerConn{
-			Dialer: d,
-			stop:   stop,
-		})
-		defer func() {
-			if err != nil {
-				_ = c.close(fmt.Errorf("dial failure: %w", err))
+			return nil, ctx.Err()
+		case <-signaling.Context().Done():
+			return nil, context.Cause(signaling.Context())
+		case signal, ok := <-signals:
+			if !ok {
+				return nil, net.ErrClosed
 			}
-		}()
-		c.sctp.OnDataChannel(func(channel *webrtc.DataChannel) {
-			// For client connections, the server should never open a data channel.
-			//
-			// This handler function itself is invoked while holding an internal lock, so call close in a goroutine to avoid deadlock.
-			go c.close(fmt.Errorf("data channel %q was unexpectedly opened by remote peer", channel.Label()))
-		})
-
-		// Encode an offer using the local parameters!
-		dtlsParams.Role = webrtc.DTLSRoleServer
-		offer, err := description{
-			ice:  iceParams,
-			dtls: dtlsParams,
-			sctp: sctpCapabilities,
-		}.encode()
-		if err != nil {
-			return nil, fmt.Errorf("encode offer: %w", err)
-		}
-		if err := signaling.Signal(ctx, &Signal{
-			Type:         SignalTypeOffer,
-			Data:         string(offer),
-			ConnectionID: d.ConnectionID,
-			NetworkID:    networkID,
-		}); err != nil {
-			return nil, fmt.Errorf("signal offer: %w", err)
-		}
-		for i, candidate := range candidates {
-			if err := signaling.Signal(ctx, &Signal{
-				Type:         SignalTypeCandidate,
-				Data:         formatICECandidate(i, candidate, iceParams),
-				ConnectionID: d.ConnectionID,
-				NetworkID:    networkID,
-			}); err != nil {
-				return nil, fmt.Errorf("signal candidate: %w", err)
-			}
-		}
-
-		for {
-			select {
-			case <-c.ctx.Done():
-				return nil, context.Cause(c.ctx)
-			case <-ctx.Done():
-				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					d.signalError(signaling, networkID, ErrorCodeNegotiationTimeoutWaitingForResponse)
+			switch signal.Type {
+			case SignalTypeAnswer:
+				s := &sdp.SessionDescription{}
+				if err := s.UnmarshalString(signal.Data); err != nil {
+					d.signalError(signaling, networkID, ErrorCodeFailedToSetRemoteDescription)
+					return nil, fmt.Errorf("decode answer: %w", err)
 				}
-				return nil, ctx.Err()
-			case <-signaling.Context().Done():
-				return nil, context.Cause(signaling.Context())
-			case signal, ok := <-signals:
-				if !ok {
-					return nil, net.ErrClosed
+				desc, err := parseDescription(s)
+				if err != nil {
+					d.signalError(signaling, networkID, ErrorCodeFailedToSetRemoteDescription)
+					return nil, fmt.Errorf("parse answer: %w", err)
 				}
-				switch signal.Type {
-				case SignalTypeAnswer:
-					s := &sdp.SessionDescription{}
-					if err := s.UnmarshalString(signal.Data); err != nil {
+				for _, candidate := range desc.candidates {
+					// Non-trickle ICE connection such as Realms may include candidates in a single SDP.
+					if err := c.addRemoteCandidate(candidate); err != nil {
 						d.signalError(signaling, networkID, ErrorCodeFailedToSetRemoteDescription)
-						return nil, fmt.Errorf("decode answer: %w", err)
-					}
-					desc, err := parseDescription(s)
-					if err != nil {
-						d.signalError(signaling, networkID, ErrorCodeFailedToSetRemoteDescription)
-						return nil, fmt.Errorf("parse answer: %w", err)
-					}
-					if err := c.addRemoteCandidatesFromSDP(s); err != nil {
-						d.signalError(signaling, networkID, ErrorCodeCandidateAdd)
 						return nil, fmt.Errorf("add bundled answer candidate: %w", err)
 					}
+				}
 
-					go d.handleConn(c, signals)
+				go d.handleConn(c, signals)
 
-					select {
-					case <-c.ctx.Done():
-						return nil, context.Cause(c.ctx)
-					case <-ctx.Done():
-						if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				select {
+				case <-c.ctx.Done():
+					return nil, context.Cause(c.ctx)
+				case <-ctx.Done():
+					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+						d.signalError(signaling, networkID, ErrorCodeInactivityTimeout)
+					}
+					if err := context.Cause(c.ctx); err != nil {
+						return nil, err
+					}
+					return nil, ctx.Err()
+				case <-c.candidateReceived:
+					c.log.Debug("received first candidate")
+					if err := d.startTransports(ctx, c, desc); err != nil {
+						if errors.Is(err, context.DeadlineExceeded) {
 							d.signalError(signaling, networkID, ErrorCodeInactivityTimeout)
 						}
-						if err := context.Cause(c.ctx); err != nil {
-							return nil, err
-						}
-						return nil, ctx.Err()
-					case <-c.candidateReceived:
-						c.log.Debug("received first candidate")
-						if err := d.startTransports(ctx, c, desc); err != nil {
-							if errors.Is(err, context.DeadlineExceeded) {
-								d.signalError(signaling, networkID, ErrorCodeInactivityTimeout)
-							}
-							return nil, fmt.Errorf("start transports: %w", err)
-						}
-						return c, nil
+						return nil, fmt.Errorf("start transports: %w", err)
 					}
-				default:
-					err = c.handleSignal(signal)
-					if err != nil {
-						d.signalError(signaling, networkID, ErrorCodeIncomingConnectionIgnored)
-						return nil, fmt.Errorf("handle signal: %w", err)
-					}
+					return c, nil
+				}
+			default:
+				err = c.handleSignal(signal)
+				if err != nil {
+					d.signalError(signaling, networkID, ErrorCodeIncomingConnectionIgnored)
+					return nil, fmt.Errorf("handle signal: %w", err)
 				}
 			}
 		}
@@ -240,9 +187,8 @@ func (d dialerConn) log() *slog.Logger {
 	return d.Log.With(slog.String("src", "dialer"))
 }
 
-// signalError signals a Signal of SignalTypeError into the remote connection using the
-// [Signaling] implementation with the remote network ID and the code of the error
-// occurred.
+// signalError sends a SignalTypeError to the remote connection using the
+// provided [Signaling] implementation, remote network ID, and error code.
 func (d Dialer) signalError(signaling Signaling, networkID string, code int) {
 	_ = signaling.Signal(context.Background(), &Signal{
 		Type:         SignalTypeError,
@@ -252,10 +198,10 @@ func (d Dialer) signalError(signaling Signaling, networkID string, code int) {
 	})
 }
 
-// startTransports establishes ICE transport as [webrtc.ICERoleControlling], DTLS transport as
-// [webrtc.DTLSRoleClient], and SCTP transport using the parameters included in the remote description.
-// Once SCTP transport has established, it will create two data channels labeled 'ReliableDataChannel'
-// and 'UnreliableDataChannel'. All methods are called with awareness of the [context.Context].
+// startTransports starts the ICE transport as [webrtc.ICERoleControlling],
+// then starts DTLS and SCTP using the parameters from the remote description.
+// After SCTP is established, it creates the 'ReliableDataChannel' and
+// 'UnreliableDataChannel'. All operations respect the provided [context.Context].
 func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *description) error {
 	conn.log.Debug("starting ICE transport as controller")
 	iceRole := webrtc.ICERoleControlling
@@ -267,7 +213,7 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 		return fmt.Errorf("start ICE: %w", err)
 	}
 
-	conn.log.Debug("starting DTLS transport as client")
+	conn.log.Debug("starting DTLS transport", slog.String("remoteRole", desc.dtls.Role.String()))
 	if err := withContextCancel(ctx, func() error {
 		return conn.dtls.Start(desc.dtls)
 	}, func() {

--- a/discovery/dial_test.go
+++ b/discovery/dial_test.go
@@ -1,3 +1,5 @@
+//go:build manual
+
 package discovery
 
 import (

--- a/discovery/dial_test.go
+++ b/discovery/dial_test.go
@@ -1,0 +1,64 @@
+package discovery
+
+import (
+	"context"
+	"math/rand/v2"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/df-mc/go-nethernet"
+)
+
+// TestDial demonstrates a client connecting to the host.
+func TestDial(t *testing.T) {
+	cfg := ListenConfig{
+		NetworkID: rand.Uint64(),
+	}
+	d, err := cfg.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	ticker := time.NewTicker(time.Second * 2)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			var (
+				serverData = &ServerData{}
+				networkID  uint64
+			)
+			for id, response := range d.Responses() {
+				if err := serverData.UnmarshalBinary(response); err != nil {
+					t.Errorf("error decoding server data: %s", err)
+				}
+				networkID = id
+				goto FOUND
+			}
+			continue
+		FOUND:
+			t.Logf("Found host: %q (%s)", serverData.LevelName, serverData.ServerName)
+			dial(t, networkID, d, serverData)
+			return
+		case <-t.Context().Done():
+			return
+		}
+	}
+}
+
+func dial(t testing.TB, networkID uint64, signaling nethernet.Signaling, serverData *ServerData) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+	defer cancel()
+
+	var d nethernet.Dialer
+	conn, err := d.DialContext(ctx, strconv.FormatUint(networkID, 10), signaling)
+	if err != nil {
+		t.Fatalf("error connecting to %s: %s", serverData.ServerName, err)
+	}
+	defer conn.Close()
+
+	t.Logf("connected, latency: %s", conn.Latency())
+}

--- a/listener.go
+++ b/listener.go
@@ -251,127 +251,92 @@ func (l *Listener) handleOffer(signal *Signal) error {
 	if err != nil {
 		return wrapSignalError(fmt.Errorf("obtain credentials: %w", err), ErrorCodeSignalingTurnAuthFailed)
 	}
-	gatherer, err := l.conf.API.NewICEGatherer(gatherOptions(credentials))
+
+	c, err := newConn(l.conf.API, credentials, signal.ConnectionID, signal.NetworkID, l.networkID, l)
 	if err != nil {
-		return wrapSignalError(fmt.Errorf("create ICE gatherer: %w", err), ErrorCodeFailedToCreatePeerConnection)
+		return wrapSignalError(fmt.Errorf("create peer connection: %w", err), ErrorCodeFailedToCreatePeerConnection)
 	}
+	established := false
+	defer func() {
+		if !established {
+			_ = c.Close()
+		}
+	}()
+	for _, candidate := range desc.candidates {
+		// Non-trickle ICE connection may include candidates in a single SDP.
+		if err := c.addRemoteCandidate(candidate); err != nil {
+			return wrapSignalError(fmt.Errorf("add inline candidate: %w", err), ErrorCodeFailedToSetRemoteDescription)
+		}
+	}
+	c.description.dtls.Role = l.answererRole(desc.dtls.Role, c.ice)
 
+	// Register a callback function immediately since the remote peer
+	// may open data channels at any time while ICE candidates are being signaled.
 	var (
-		// Local candidates gathered by webrtc.ICEGatherer
-		candidates []webrtc.ICECandidate
-		// Notifies that gathering for local candidates has finished.
-		gatherFinished = make(chan struct{})
+		opened        atomic.Uint32
+		channelsReady = make(chan struct{})
 	)
-	gatherer.OnLocalCandidate(func(candidate *webrtc.ICECandidate) {
-		if candidate == nil {
-			close(gatherFinished)
-			return
-		}
-		candidates = append(candidates, *candidate)
-	})
-	if err := gatherer.Gather(); err != nil {
-		return wrapSignalError(fmt.Errorf("gather local candidates: %w", err), ErrorCodeFailedToCreatePeerConnection)
-	}
-
-	select {
-	case <-ctx.Done():
-		_ = gatherer.Close()
-		return wrapSignalError(fmt.Errorf("gather local candidates: %w", ctx.Err()), ErrorCodeFailedToCreatePeerConnection)
-	case <-gatherFinished:
-		ice := l.conf.API.NewICETransport(gatherer)
-		dtls, err := l.conf.API.NewDTLSTransport(ice, nil)
-		if err != nil {
-			return wrapSignalError(fmt.Errorf("create DTLS transport: %w", err), ErrorCodeFailedToCreatePeerConnection)
-		}
-		sctp := l.conf.API.NewSCTPTransport(dtls)
-
-		iceParams, err := ice.GetLocalParameters()
-		if err != nil {
-			return wrapSignalError(fmt.Errorf("obtain local ICE parameters: %w", err), ErrorCodeFailedToCreateAnswer)
-		}
-		dtlsParams, err := dtls.GetLocalParameters()
-		if err != nil {
-			return wrapSignalError(fmt.Errorf("obtain local DTLS parameters: %w", err), ErrorCodeFailedToCreateAnswer)
-		}
-		if len(dtlsParams.Fingerprints) == 0 {
-			return wrapSignalError(errors.New("local DTLS parameters has no fingerprints"), ErrorCodeFailedToCreateAnswer)
-		}
-
-		c := newConn(ice, dtls, sctp, signal.ConnectionID, signal.NetworkID, Addr{
-			NetworkID:  l.networkID,
-			Candidates: candidates,
-		}, l)
-		established := false
-		defer func() {
-			if !established {
-				_ = c.Close()
-			}
-		}()
-		if err := c.addRemoteCandidatesFromSDP(d); err != nil {
-			return wrapSignalError(fmt.Errorf("add bundled offer candidate: %w", err), ErrorCodeCandidateAdd)
-		}
-
-		// Register a callback function immediately since the remote peer
-		// may open data channels at any time while ICE candidates are being signaled.
-		channelsReady := make(chan struct{})
-		var opened atomic.Uint32
-		c.sctp.OnDataChannel(func(channel *webrtc.DataChannel) {
-			for r := range messageReliabilityCapacity {
-				if r.Valid(channel) {
-					ch := wrapDataChannel(channel, r, c)
-					if existing := c.storeChannel(r, ch); existing != nil {
-						go c.close(fmt.Errorf("data channel created for same reliability parameters: %q", r.Parameters().Label))
-						return
-					}
-					channel.OnOpen(sync.OnceFunc(func() {
-						// If all data channels have been opened by remote peer, we can signal that the connection is ready.
-						if opened.Add(1) == uint32(messageReliabilityCapacity) {
-							close(channelsReady)
-						}
-					}))
+	c.sctp.OnDataChannel(func(channel *webrtc.DataChannel) {
+		for r := range messageReliabilityCapacity {
+			if r.Valid(channel) {
+				ch := wrapDataChannel(channel, r, c)
+				if existing := c.storeChannel(r, ch); existing != nil {
+					go c.close(fmt.Errorf("data channel created for same reliability parameters: %q", r.Parameters().Label))
 					return
 				}
-			}
-			go c.close(fmt.Errorf("invalid data channel opened: %q", channel.Label()))
-		})
-
-		// Encode an answer using the local parameters!
-		sctpCapabilities := sctp.GetCapabilities()
-		answer, err := description{
-			ice:  iceParams,
-			dtls: dtlsParams,
-			sctp: sctpCapabilities,
-		}.encode()
-		if err != nil {
-			return wrapSignalError(fmt.Errorf("encode answer: %w", err), ErrorCodeFailedToCreateAnswer)
-		}
-
-		if err := l.signaling.Signal(ctx, &Signal{
-			Type:         SignalTypeAnswer,
-			ConnectionID: signal.ConnectionID,
-			Data:         string(answer),
-			NetworkID:    signal.NetworkID,
-		}); err != nil {
-			// I don't think the error code will be signaled back to the remote connection, but just in case.
-			return wrapSignalError(fmt.Errorf("signal answer: %w", err), ErrorCodeSignalingFailedToSend)
-		}
-		for i, candidate := range candidates {
-			if err := l.signaling.Signal(ctx, &Signal{
-				Type:         SignalTypeCandidate,
-				ConnectionID: signal.ConnectionID,
-				Data:         formatICECandidate(i, candidate, iceParams),
-				NetworkID:    signal.NetworkID,
-			}); err != nil {
-				// I don't think the error code will be signaled back to the remote connection, but just in case.
-				return wrapSignalError(fmt.Errorf("signal candidate: %w", err), ErrorCodeSignalingFailedToSend)
+				channel.OnOpen(sync.OnceFunc(func() {
+					// If all data channels have been opened by remote peer, we can signal that the connection is ready.
+					if opened.Add(1) == uint32(messageReliabilityCapacity) {
+						close(channelsReady)
+					}
+				}))
+				return
 			}
 		}
+		go c.close(fmt.Errorf("invalid data channel opened: %q", channel.Label()))
+	})
 
-		l.connections.Store(c.remoteAddr().String(), c)
-		go l.handleConn(c, desc, channelsReady)
-		established = true
+	// Encode an answer using the local parameters!
+	answer, err := c.description.encode()
+	if err != nil {
+		return wrapSignalError(fmt.Errorf("encode answer: %w", err), ErrorCodeFailedToCreateAnswer)
+	}
 
-		return nil
+	if err := l.signaling.Signal(ctx, &Signal{
+		Type:         SignalTypeAnswer,
+		ConnectionID: signal.ConnectionID,
+		Data:         string(answer),
+		NetworkID:    signal.NetworkID,
+	}); err != nil {
+		// I don't think the error code will be signaled back to the remote connection, but just in case.
+		return wrapSignalError(fmt.Errorf("signal answer: %w", err), ErrorCodeSignalingFailedToSend)
+	}
+
+	if err := c.gatherCandidates(l.signaling); err != nil {
+		// I don't think the error code will be signaled back to the remote connection, but just in case.
+		return wrapSignalError(fmt.Errorf("gather candidates: %w", err), ErrorCodeFailedToCreatePeerConnection)
+	}
+
+	l.connections.Store(c.remoteAddr().String(), c)
+	go l.handleConn(c, desc, channelsReady)
+	established = true
+	return nil
+}
+
+// answererRole returns the local [webrtc.DTLSRole] for an answer based on the
+// role signaled by the remote peer. If the remote peer uses
+// [webrtc.DTLSRoleAuto], the role is chosen from the ICE transport role.
+func (l *Listener) answererRole(role webrtc.DTLSRole, iceTransport *webrtc.ICETransport) webrtc.DTLSRole {
+	switch role {
+	case webrtc.DTLSRoleServer:
+		return webrtc.DTLSRoleClient
+	case webrtc.DTLSRoleClient:
+		return webrtc.DTLSRoleServer
+	default:
+		if iceTransport.Role() == webrtc.ICERoleControlling {
+			return webrtc.DTLSRoleServer
+		}
+		return webrtc.DTLSRoleClient
 	}
 }
 
@@ -468,9 +433,10 @@ func (l *Listener) handleConn(conn *Conn, d *description, channelsReady <-chan s
 	}
 }
 
-// startTransports establishes ICE transport as [webrtc.ICERoleControlled], DTLS transport as [webrtc.DTLSRoleServer]
-// and SCTP transport using the remote description. It will block until two data channels labeled 'ReliableDataChannel'
-// and 'UnreliableDataChannel' are created by the remote connection. The [context.Context] is used to cancel blocking.
+// startTransports starts ICE as [webrtc.ICERoleControlled], then starts DTLS
+// and SCTP using the remote description. It blocks until the remote peer has
+// created both 'ReliableDataChannel' and 'UnreliableDataChannel'. The provided
+// [context.Context] is used to control the deadline.
 func (l *Listener) startTransports(ctx context.Context, conn *Conn, d *description, channelsReady <-chan struct{}) error {
 	conn.log.Debug("starting ICE transport as controlled")
 	iceRole := webrtc.ICERoleControlled
@@ -482,7 +448,7 @@ func (l *Listener) startTransports(ctx context.Context, conn *Conn, d *descripti
 		return fmt.Errorf("start ICE: %w", err)
 	}
 
-	conn.log.Debug("starting DTLS transport as server")
+	conn.log.Debug("starting DTLS transport", slog.String("remoteRole", d.dtls.Role.String()))
 	if err := withContextCancel(ctx, func() error {
 		return conn.dtls.Start(d.dtls)
 	}, func() {

--- a/listener.go
+++ b/listener.go
@@ -268,7 +268,7 @@ func (l *Listener) handleOffer(signal *Signal) error {
 			return wrapSignalError(fmt.Errorf("add inline candidate: %w", err), ErrorCodeFailedToSetRemoteDescription)
 		}
 	}
-	c.description.dtls.Role = l.answererRole(desc.dtls.Role, c.ice)
+	c.description.dtls.Role = l.answererRole(desc.dtls.Role)
 
 	// Register a callback function immediately since the remote peer
 	// may open data channels at any time while ICE candidates are being signaled.
@@ -325,17 +325,15 @@ func (l *Listener) handleOffer(signal *Signal) error {
 
 // answererRole returns the local [webrtc.DTLSRole] for an answer based on the
 // role signaled by the remote peer. If the remote peer uses
-// [webrtc.DTLSRoleAuto], the role is chosen from the ICE transport role.
-func (l *Listener) answererRole(role webrtc.DTLSRole, iceTransport *webrtc.ICETransport) webrtc.DTLSRole {
+// [webrtc.DTLSRoleAuto], it will be [webrtc.DTLSRoleClient] since the ICE
+// transport will always start as controlled.
+func (l *Listener) answererRole(role webrtc.DTLSRole) webrtc.DTLSRole {
 	switch role {
 	case webrtc.DTLSRoleServer:
 		return webrtc.DTLSRoleClient
 	case webrtc.DTLSRoleClient:
 		return webrtc.DTLSRoleServer
 	default:
-		if iceTransport.Role() == webrtc.ICERoleControlling {
-			return webrtc.DTLSRoleServer
-		}
 		return webrtc.DTLSRoleClient
 	}
 }


### PR DESCRIPTION
Implemented Trickle ICE to match vanilla behavior.

`newConn` now creates the underlying transports directly, which removes duplicated setup logic shared by the dialer and listener.

Connection establishment may now be faster because negotiation no longer waits for all local ICE candidates to be gathered before sending the offer or answer.

The `setup` attribute on answer SDP generated by listener is now based on the remote role.