### PR TITLE
Add support for disabling Trickle ICE

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -527,44 +527,87 @@ func parseDescription(d *sdp.SessionDescription) (*description, error) {
 	}, nil
 }
 
-// gatherCandidates starts gathering local candidates and signaling them to the
-// remote peer using the provided [Signaling] implementation.
-func (conn *Conn) gatherCandidates(signaling Signaling) error {
-	var candidateIndex atomic.Uint32
+// gatherCandidates blocks until local ICE gathering completes and returns every
+// candidate produced by the gatherer.
+//
+// It is used for non-trickle ICE, where all local candidates must be known
+// before the offer or answer is encoded so they can be embedded into the SDP.
+//
+// The gather is aborted if ctx is canceled or if conn is closed.
+func (conn *Conn) gatherCandidates(ctx context.Context) (candidates []webrtc.ICECandidate, _ error) {
+	complete := make(chan struct{})
+	conn.gatherer.OnLocalCandidate(func(candidate *webrtc.ICECandidate) {
+		if candidate == nil {
+			conn.log.Debug("end of candidate")
+			close(complete)
+			return
+		}
+		candidates = append(candidates, *candidate)
+	})
+	if err := conn.gatherer.Gather(); err != nil {
+		return nil, fmt.Errorf("start gathering local candidates: %w", err)
+	}
+	select {
+	case <-complete:
+		return candidates, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-conn.ctx.Done():
+		return nil, context.Cause(conn.ctx)
+	}
+}
+
+// trickleCandidates starts local ICE gathering for trickle ICE and signals each
+// discovered candidate to the remote peer through signaling.
+//
+// It must be called after the local offer or answer has been signaled, because
+// candidates are sent as separate [SignalTypeCandidate] messages instead of
+// being embedded in the SDP.
+func (conn *Conn) trickleCandidates(signaling Signaling) error {
+	var candidateIndex atomic.Uint32 // incremented when allocating 'network-id' for each candidate
 	conn.gatherer.OnLocalCandidate(func(candidate *webrtc.ICECandidate) {
 		// ICEGatherer already tracks its internal state, so we don't need to check if the connection is closed.
 		if candidate == nil {
-			conn.log.Debug("completed gathering local candidates")
+			conn.log.Debug("end of candidate")
 			return
 		}
-
 		// Signal the local candidate in a goroutine so candidate gathering is never blocked by signaling.
-		go func() {
-			ctx, cancel := context.WithTimeout(conn.Context(), time.Second*15)
-			defer cancel()
-			if err := signaling.Signal(ctx, &Signal{
-				Type:         SignalTypeCandidate,
-				ConnectionID: conn.id,
-				Data:         formatICECandidate(int(candidateIndex.Add(1)-1), *candidate, conn.description.ice),
-				NetworkID:    conn.networkID,
-			}); err != nil {
-				errCtx, cancel := context.WithTimeout(conn.Context(), time.Second*15)
-				defer cancel()
-
-				// I don't think the error code will be signaled back to the remote connection, but just in case.
-				if err := signaling.Signal(errCtx, &Signal{
-					Type:         SignalTypeError,
-					ConnectionID: conn.id,
-					Data:         strconv.Itoa(ErrorCodeSignalingFailedToSend),
-					NetworkID:    conn.networkID,
-				}); err != nil {
-					conn.log.Error("error signaling error", slog.Any("error", err))
-				}
-				_ = conn.close(fmt.Errorf("signal candidate: %w", err))
-			}
-		}()
+		// It uses [Conn.Context] as the parent context so signaling stops once the connection is closed.
+		go conn.trickleCandidate(signaling, formatICECandidate(int(candidateIndex.Add(1)-1), *candidate, conn.description.ice))
 	})
 	return conn.gatherer.Gather()
+}
+
+// trickleCandidate sends one gathered candidate to the remote peer as a
+// [SignalTypeCandidate] signal.
+//
+// It should run in its own goroutine to prevent blocking the ICE gatherer,
+// which could otherwise cause the ICE transport to enter the failed state.
+func (conn *Conn) trickleCandidate(signaling Signaling, data string) {
+	// Use [Conn.Context] as the parent context so signaling stops once the
+	// connection is closed.
+	ctx, cancel := context.WithTimeout(conn.Context(), time.Second*15)
+	defer cancel()
+	if err := signaling.Signal(ctx, &Signal{
+		Type:         SignalTypeCandidate,
+		ConnectionID: conn.id,
+		Data:         data,
+		NetworkID:    conn.networkID,
+	}); err != nil {
+		errCtx, cancel := context.WithTimeout(conn.Context(), time.Second*15)
+		defer cancel()
+
+		// I don't think the error code will be signaled back to the remote connection, but just in case.
+		if err := signaling.Signal(errCtx, &Signal{
+			Type:         SignalTypeError,
+			ConnectionID: conn.id,
+			Data:         strconv.Itoa(ErrorCodeSignalingFailedToSend),
+			NetworkID:    conn.networkID,
+		}); err != nil {
+			conn.log.Error("error signaling error", slog.Any("error", err))
+		}
+		_ = conn.close(fmt.Errorf("signal candidate: %w", err))
+	}
 }
 
 // description contains parameters necessary for starting ICE, DTLS, and SCTP transport within a Conn.
@@ -623,8 +666,16 @@ func (desc description) encode() ([]byte, error) {
 			},
 		},
 	}
+
+	for i, candidate := range desc.candidates {
+		media.Attributes = append(media.Attributes, sdp.Attribute{
+			Key:   sdp.AttrKeyCandidate,
+			Value: formatICECandidate(i, candidate, desc.ice),
+		})
+	}
+
 	media.WithICECredentials(desc.ice.UsernameFragment, desc.ice.Password)
-	media.WithValueAttribute("ice-options", "trickle")
+	media.WithValueAttribute(sdp.AttrKeyICEOptions, "trickle") // ice-options:trickle is always present even if the connection is non-trickle
 	for _, fingerprint := range desc.dtls.Fingerprints {
 		media.WithFingerprint(fingerprint.Algorithm, fingerprint.Value)
 	}
@@ -632,14 +683,6 @@ func (desc description) encode() ([]byte, error) {
 	media.WithValueAttribute(sdp.AttrKeyMID, "0")
 	media.WithValueAttribute("sctp-port", "5000")
 	media.WithValueAttribute("max-message-size", strconv.FormatUint(uint64(desc.sctp.MaxMessageSize), 10))
-
-	// We don't populate ICE candidates in the SDP but just in case.
-	for _, candidate := range desc.candidates {
-		d.Attributes = append(d.Attributes, sdp.Attribute{
-			Key:   sdp.AttrKeyCandidate,
-			Value: candidate.String(),
-		})
-	}
 
 	return d.WithMedia(media).Marshal()
 }
@@ -668,8 +711,8 @@ func (desc description) connectionRole(role webrtc.DTLSRole) sdp.ConnectionRole 
 // The caller must register [SCTPTransport.OnDataChannel] immediately on
 // the returned Conn, then use [Conn.description] to signal an offer or
 // answer to the remote peer.
-func newConn(api *webrtc.API, credentials *Credentials, id uint64, networkID, localNetworkID string, n negotiator) (*Conn, error) {
-	gatherer, err := api.NewICEGatherer(gatherOptions(credentials))
+func newConn(api *webrtc.API, gathererOpts webrtc.ICEGatherOptions, id uint64, networkID, localNetworkID string, n negotiator) (*Conn, error) {
+	gatherer, err := api.NewICEGatherer(gathererOpts)
 	if err != nil {
 		return nil, wrapSignalError(fmt.Errorf("create ICE gatherer: %w", err), ErrorCodeFailedToCreatePeerConnection)
 	}

--- a/conn.go
+++ b/conn.go
@@ -667,6 +667,11 @@ func (desc description) encode() ([]byte, error) {
 		},
 	}
 
+	// When Trickle ICE is disabled, local ICE candidates are embedded directly in
+	// the SDP instead of being sent later as separate candidate signals.
+	//
+	// This behavior can be only seen on dedicated servers with the
+	// 'nethernet-disable-trickle-ice' setting property set to 'true' (including Realms).
 	for i, candidate := range desc.candidates {
 		media.Attributes = append(media.Attributes, sdp.Attribute{
 			Key:   sdp.AttrKeyCandidate,

--- a/credentials.go
+++ b/credentials.go
@@ -19,7 +19,8 @@ type ICEServer struct {
 // gatherOptions transforms the given Credentials into a [webrtc.ICEGatherOptions] for gathering
 // local ICE candidates with [webrtc.ICEGatherer]. If the given credentials are nil or contain no ICE
 // servers, it will return a zero value.
-func gatherOptions(credentials *Credentials) (opts webrtc.ICEGatherOptions) {
+func gatherOptions(credentials *Credentials, policy webrtc.ICEGatherPolicy) webrtc.ICEGatherOptions {
+	opts := webrtc.ICEGatherOptions{ICEGatherPolicy: policy}
 	if credentials != nil && len(credentials.ICEServers) > 0 {
 		opts.ICEServers = make([]webrtc.ICEServer, len(credentials.ICEServers))
 		for i, server := range credentials.ICEServers {

--- a/dial.go
+++ b/dial.go
@@ -39,13 +39,18 @@ type Dialer struct {
 	// as relayed candidates from TURN servers only.
 	ICEGatherPolicy webrtc.ICEGatherPolicy
 
-	// DisableTrickleICE disables trickle ICE for the connection negotiation.
+	// DisableTrickleICE disables trickle ICE for connection negotiation.
 	//
-	// When set, the dialer waits for ICE gathering to complete and includes all
-	// local candidates in the initial offer SDP. Otherwise, candidates are sent
-	// incrementally as separate [SignalTypeCandidate] signals after the offer is
-	// signaled. This may slow down connection establishment because the initial
-	// offer cannot be sent until candidate gathering completes.
+	// When set to true, the dialer waits for ICE gathering to complete and embeds
+	// all local candidates in the initial offer SDP. Otherwise, candidates are
+	// signaled incrementally as separate [SignalTypeCandidate] signals after the
+	// offer is sent.
+	//
+	// This may slow connection establishment because the initial offer cannot be
+	// sent until candidate gathering completes.
+	//
+	// This behavior can be seen when connecting to dedicated servers with the
+	// 'nethernet-disable-trickle-ice' setting property set to 'true'.
 	DisableTrickleICE bool
 }
 

--- a/dial.go
+++ b/dial.go
@@ -31,6 +31,22 @@ type Dialer struct {
 	// set from [webrtc.NewAPI]. The [webrtc.SettingEngine] of the API should not allow detaching data channels, as it requires
 	// additional steps on the Conn (which cannot be determined by the Conn).
 	API *webrtc.API
+
+	// ICEGatherPolicy limits which local ICE candidates are gathered for the
+	// connection.
+	//
+	// It may be used to restrict connectivity to specific candidate types, such
+	// as relayed candidates from TURN servers only.
+	ICEGatherPolicy webrtc.ICEGatherPolicy
+
+	// DisableTrickleICE disables trickle ICE for the connection negotiation.
+	//
+	// When set, the dialer waits for ICE gathering to complete and includes all
+	// local candidates in the initial offer SDP. Otherwise, candidates are sent
+	// incrementally as separate [SignalTypeCandidate] signals after the offer is
+	// signaled. This may slow down connection establishment because the initial
+	// offer cannot be sent until candidate gathering completes.
+	DisableTrickleICE bool
 }
 
 // DialContext establishes a Conn with a remote network referenced by the ID. The Signaling is used to signal
@@ -60,7 +76,7 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 			stop()
 		}
 	}()
-	c, err := newConn(d.API, credentials, d.ConnectionID, networkID, signaling.NetworkID(), dialerConn{
+	c, err := newConn(d.API, gatherOptions(credentials, d.ICEGatherPolicy), d.ConnectionID, networkID, signaling.NetworkID(), dialerConn{
 		Dialer: d,
 		stop:   stop,
 	})
@@ -79,6 +95,13 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 		go c.close(fmt.Errorf("data channel %q was unexpectedly opened by remote peer", channel.Label()))
 	})
 
+	if d.DisableTrickleICE {
+		c.description.candidates, err = c.gatherCandidates(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("gather local candidates (non-trickle ICE): %w", err)
+		}
+	}
+
 	// Encode an offer using the local parameters!
 	offer, err := c.description.encode()
 	if err != nil {
@@ -93,8 +116,10 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 		return nil, fmt.Errorf("signal offer: %w", err)
 	}
 
-	if err := c.gatherCandidates(signaling); err != nil {
-		return nil, fmt.Errorf("gather candidates: %w", err)
+	if !d.DisableTrickleICE {
+		if err := c.trickleCandidates(signaling); err != nil {
+			return nil, fmt.Errorf("start gathering local candidates: %w", err)
+		}
 	}
 
 	for {

--- a/listener.go
+++ b/listener.go
@@ -51,11 +51,16 @@ type ListenConfig struct {
 
 	// DisableTrickleICE disables trickle ICE for connection negotiation.
 	//
-	// When set, the listener waits for ICE gathering to complete and includes
-	// all local candidates in the answer SDP. Otherwise, candidates are sent
-	// incrementally as separate [SignalTypeCandidate] signals after the answer
-	// is signaled. This may slow down connection establishment because the
-	// answer cannot be sent until candidate gathering completes.
+	// When set to true, the listener waits for ICE gathering to complete and embeds
+	// all local candidates in the answer SDP. Otherwise, candidates are signaled
+	// incrementally as separate [SignalTypeCandidate] signals after the answer is
+	// sent.
+	//
+	// This may slow connection establishment because the answer cannot be sent
+	// until candidate gathering completes.
+	//
+	// This behavior can be seen on dedicated servers with the
+	// 'nethernet-disable-trickle-ice' setting property set to 'true'.
 	DisableTrickleICE bool
 }
 

--- a/listener.go
+++ b/listener.go
@@ -41,6 +41,22 @@ type ListenConfig struct {
 	// to be returned (likely using [context.WithCancel] or [context.WithTimeout]). If the deadline of the context
 	// is exceeded, a Signal of SignalTypeError with ErrorCodeNegotiationTimeoutWaitingForAccept will be signaled back.
 	NegotiationContext func(parent context.Context) context.Context
+
+	// ICEGatherPolicy limits which local ICE candidates are gathered for
+	// accepted connections.
+	//
+	// It may be used to restrict connectivity to specific candidate types, such
+	// as relayed candidates from TURN servers only.
+	ICEGatherPolicy webrtc.ICEGatherPolicy
+
+	// DisableTrickleICE disables trickle ICE for connection negotiation.
+	//
+	// When set, the listener waits for ICE gathering to complete and includes
+	// all local candidates in the answer SDP. Otherwise, candidates are sent
+	// incrementally as separate [SignalTypeCandidate] signals after the answer
+	// is signaled. This may slow down connection establishment because the
+	// answer cannot be sent until candidate gathering completes.
+	DisableTrickleICE bool
 }
 
 // Listen listens on the local network ID specified by the Signaling implementation. It returns a Listener
@@ -252,7 +268,7 @@ func (l *Listener) handleOffer(signal *Signal) error {
 		return wrapSignalError(fmt.Errorf("obtain credentials: %w", err), ErrorCodeSignalingTurnAuthFailed)
 	}
 
-	c, err := newConn(l.conf.API, credentials, signal.ConnectionID, signal.NetworkID, l.networkID, l)
+	c, err := newConn(l.conf.API, gatherOptions(credentials, l.conf.ICEGatherPolicy), signal.ConnectionID, signal.NetworkID, l.networkID, l)
 	if err != nil {
 		return wrapSignalError(fmt.Errorf("create peer connection: %w", err), ErrorCodeFailedToCreatePeerConnection)
 	}
@@ -262,6 +278,12 @@ func (l *Listener) handleOffer(signal *Signal) error {
 			_ = c.Close()
 		}
 	}()
+	if l.conf.DisableTrickleICE {
+		c.description.candidates, err = c.gatherCandidates(ctx)
+		if err != nil {
+			return wrapSignalError(fmt.Errorf("gather local candidates: %w", err), ErrorCodeICE)
+		}
+	}
 	for _, candidate := range desc.candidates {
 		// Non-trickle ICE connection may include candidates in a single SDP.
 		if err := c.addRemoteCandidate(candidate); err != nil {
@@ -312,9 +334,10 @@ func (l *Listener) handleOffer(signal *Signal) error {
 		return wrapSignalError(fmt.Errorf("signal answer: %w", err), ErrorCodeSignalingFailedToSend)
 	}
 
-	if err := c.gatherCandidates(l.signaling); err != nil {
-		// I don't think the error code will be signaled back to the remote connection, but just in case.
-		return wrapSignalError(fmt.Errorf("gather candidates: %w", err), ErrorCodeFailedToCreatePeerConnection)
+	if !l.conf.DisableTrickleICE {
+		if err := c.trickleCandidates(l.signaling); err != nil {
+			return wrapSignalError(fmt.Errorf("start gathering local candidates: %w", err), ErrorCodeFailedToCreatePeerConnection)
+		}
 	}
 
 	l.connections.Store(c.remoteAddr().String(), c)


### PR DESCRIPTION
This PR adds an option to disable Trickle ICE during connection negotiation.

This behavior can be observed on dedicated servers with the `nethernet-disable-trickle-ice=true` property set (such as Realms).