### PR TITLE
Follow-up fixes for trickle-ice

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -716,7 +716,7 @@ func (desc description) connectionRole(role webrtc.DTLSRole) sdp.ConnectionRole 
 // The caller must register [SCTPTransport.OnDataChannel] immediately on
 // the returned Conn, then use [Conn.description] to signal an offer or
 // answer to the remote peer.
-func newConn(api *webrtc.API, gathererOpts webrtc.ICEGatherOptions, id uint64, networkID, localNetworkID string, n negotiator) (*Conn, error) {
+func newConn(api *webrtc.API, gathererOpts webrtc.ICEGatherOptions, id uint64, networkID, localNetworkID string, n negotiator, localDescriptionErrorCode int) (*Conn, error) {
 	gatherer, err := api.NewICEGatherer(gathererOpts)
 	if err != nil {
 		return nil, wrapSignalError(fmt.Errorf("create ICE gatherer: %w", err), ErrorCodeFailedToCreatePeerConnection)
@@ -730,14 +730,14 @@ func newConn(api *webrtc.API, gathererOpts webrtc.ICEGatherOptions, id uint64, n
 
 	iceParams, err := iceTransport.GetLocalParameters()
 	if err != nil {
-		return nil, wrapSignalError(fmt.Errorf("obtain local ICE parameters: %w", err), ErrorCodeFailedToCreateAnswer)
+		return nil, wrapSignalError(fmt.Errorf("obtain local ICE parameters: %w", err), localDescriptionErrorCode)
 	}
 	dtlsParams, err := dtlsTransport.GetLocalParameters()
 	if err != nil {
-		return nil, wrapSignalError(fmt.Errorf("obtain local DTLS parameters: %w", err), ErrorCodeFailedToCreateAnswer)
+		return nil, wrapSignalError(fmt.Errorf("obtain local DTLS parameters: %w", err), localDescriptionErrorCode)
 	}
 	if len(dtlsParams.Fingerprints) == 0 {
-		return nil, wrapSignalError(errors.New("local DTLS parameters has no fingerprints"), ErrorCodeFailedToCreateAnswer)
+		return nil, wrapSignalError(errors.New("local DTLS parameters has no fingerprints"), localDescriptionErrorCode)
 	}
 	sctpCapabilities := sctpTransport.GetCapabilities()
 

--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -1,0 +1,222 @@
+package nethernet
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDialListenerTrickleICE(t *testing.T) {
+	testDialListener(t, false)
+}
+
+func TestDialListenerNonTrickleICE(t *testing.T) {
+	testDialListener(t, true)
+}
+
+func testDialListener(t *testing.T, disableTrickle bool) {
+	t.Helper()
+
+	client, server := newMemorySignalingPair("1", "2")
+	defer client.close()
+	defer server.close()
+
+	l, err := (ListenConfig{DisableTrickleICE: disableTrickle}).Listen(server)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer l.Close()
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	var d Dialer
+	d.DisableTrickleICE = disableTrickle
+	conn, err := d.DialContext(ctx, server.NetworkID(), client)
+	if err != nil {
+		t.Fatalf("DialContext() error = %v", err)
+	}
+	defer conn.Close()
+
+	var serverConn net.Conn
+	select {
+	case serverConn = <-accepted:
+	case err := <-acceptErr:
+		t.Fatalf("Accept() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Accept() timed out: %v", ctx.Err())
+	}
+	defer serverConn.Close()
+
+	if disableTrickle {
+		if got := client.signalCount(SignalTypeCandidate) + server.signalCount(SignalTypeCandidate); got != 0 {
+			t.Fatalf("candidate signals = %d, want 0 for non-trickle ICE", got)
+		}
+	} else {
+		if got := client.signalCount(SignalTypeCandidate) + server.signalCount(SignalTypeCandidate); got == 0 {
+			t.Fatal("candidate signals = 0, want trickled candidates")
+		}
+	}
+
+	read := make(chan []byte, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		b := make([]byte, 32)
+		n, err := serverConn.Read(b)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		read <- b[:n]
+	}()
+
+	const payload = "hello"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	select {
+	case got := <-read:
+		if string(got) != payload {
+			t.Fatalf("Read() = %q, want %q", got, payload)
+		}
+	case err := <-readErr:
+		t.Fatalf("Read() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Read() timed out: %v", ctx.Err())
+	}
+}
+
+type memorySignalingBus struct {
+	mu        sync.RWMutex
+	endpoints map[string]*memorySignaling
+}
+
+type memorySignaling struct {
+	id     string
+	bus    *memorySignalingBus
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu        sync.Mutex
+	next      int
+	notifiers map[int]chan<- *Signal
+
+	stats signalStats
+}
+
+type signalStats struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newMemorySignalingPair(clientID, serverID string) (*memorySignaling, *memorySignaling) {
+	bus := &memorySignalingBus{endpoints: make(map[string]*memorySignaling)}
+	client := newMemorySignaling(bus, clientID)
+	server := newMemorySignaling(bus, serverID)
+	bus.endpoints[clientID] = client
+	bus.endpoints[serverID] = server
+	return client, server
+}
+
+func newMemorySignaling(bus *memorySignalingBus, id string) *memorySignaling {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	return &memorySignaling{
+		id:        id,
+		bus:       bus,
+		ctx:       ctx,
+		cancel:    func() { cancel(net.ErrClosed) },
+		notifiers: make(map[int]chan<- *Signal),
+		stats: signalStats{
+			counts: make(map[string]int),
+		},
+	}
+}
+
+func (s *memorySignaling) Signal(ctx context.Context, signal *Signal) error {
+	s.recordSignal(signal.Type)
+	if signal.Type == SignalTypeCandidate {
+		time.Sleep(time.Millisecond)
+	}
+
+	s.bus.mu.RLock()
+	peer := s.bus.endpoints[signal.NetworkID]
+	s.bus.mu.RUnlock()
+	if peer == nil {
+		return fmt.Errorf("no endpoint found for network ID %q", signal.NetworkID)
+	}
+
+	delivered := *signal
+	delivered.NetworkID = s.id
+	return peer.deliver(ctx, &delivered)
+}
+
+func (s *memorySignaling) Notify(ch chan<- *Signal) func() {
+	s.mu.Lock()
+	id := s.next
+	s.next++
+	s.notifiers[id] = ch
+	s.mu.Unlock()
+
+	return func() {
+		s.mu.Lock()
+		delete(s.notifiers, id)
+		s.mu.Unlock()
+	}
+}
+
+func (s *memorySignaling) Context() context.Context { return s.ctx }
+
+func (*memorySignaling) Credentials(context.Context) (*Credentials, error) { return nil, nil }
+
+func (s *memorySignaling) NetworkID() string { return s.id }
+
+func (*memorySignaling) PongData([]byte) {}
+
+func (s *memorySignaling) close() { s.cancel() }
+
+func (s *memorySignaling) deliver(ctx context.Context, signal *Signal) error {
+	s.mu.Lock()
+	notifiers := make([]chan<- *Signal, 0, len(s.notifiers))
+	for _, ch := range s.notifiers {
+		notifiers = append(notifiers, ch)
+	}
+	s.mu.Unlock()
+
+	for _, ch := range notifiers {
+		delivered := *signal
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.ctx.Done():
+			return context.Cause(s.ctx)
+		case ch <- &delivered:
+		}
+	}
+	return nil
+}
+
+func (s *memorySignaling) recordSignal(signalType string) {
+	s.stats.mu.Lock()
+	defer s.stats.mu.Unlock()
+	s.stats.counts[signalType]++
+}
+
+func (s *memorySignaling) signalCount(signalType string) int {
+	s.stats.mu.Lock()
+	defer s.stats.mu.Unlock()
+	return s.stats.counts[signalType]
+}

--- a/credentials.go
+++ b/credentials.go
@@ -16,9 +16,10 @@ type ICEServer struct {
 	URLs     []string `json:"Urls"`
 }
 
-// gatherOptions transforms the given Credentials into a [webrtc.ICEGatherOptions] for gathering
-// local ICE candidates with [webrtc.ICEGatherer]. If the given credentials are nil or contain no ICE
-// servers, it will return a zero value.
+// gatherOptions transforms the given Credentials and gather policy into a
+// [webrtc.ICEGatherOptions] for gathering local ICE candidates with
+// [webrtc.ICEGatherer]. If the given credentials are nil or contain no ICE
+// servers, only the gather policy is populated.
 func gatherOptions(credentials *Credentials, policy webrtc.ICEGatherPolicy) webrtc.ICEGatherOptions {
 	opts := webrtc.ICEGatherOptions{ICEGatherPolicy: policy}
 	if credentials != nil && len(credentials.ICEServers) > 0 {

--- a/dial.go
+++ b/dial.go
@@ -84,7 +84,7 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 	c, err := newConn(d.API, gatherOptions(credentials, d.ICEGatherPolicy), d.ConnectionID, networkID, signaling.NetworkID(), dialerConn{
 		Dialer: d,
 		stop:   stop,
-	})
+	}, ErrorCodeFailedToCreateOffer)
 	if err != nil {
 		return nil, fmt.Errorf("create conn: %w", err)
 	}

--- a/listener.go
+++ b/listener.go
@@ -273,9 +273,17 @@ func (l *Listener) handleOffer(signal *Signal) error {
 		return wrapSignalError(fmt.Errorf("obtain credentials: %w", err), ErrorCodeSignalingTurnAuthFailed)
 	}
 
-	c, err := newConn(l.conf.API, gatherOptions(credentials, l.conf.ICEGatherPolicy), signal.ConnectionID, signal.NetworkID, l.networkID, l)
+	c, err := newConn(
+		l.conf.API,
+		gatherOptions(credentials, l.conf.ICEGatherPolicy),
+		signal.ConnectionID,
+		signal.NetworkID,
+		l.networkID,
+		l,
+		ErrorCodeFailedToCreateAnswer,
+	)
 	if err != nil {
-		return wrapSignalError(fmt.Errorf("create peer connection: %w", err), ErrorCodeFailedToCreatePeerConnection)
+		return fmt.Errorf("create peer connection: %w", err)
 	}
 	established := false
 	defer func() {

--- a/message.go
+++ b/message.go
@@ -125,6 +125,9 @@ type dataChannel struct {
 	// An embedded message contains the buffer that holds the segments received
 	// to now and the count of the last segment count.
 	*message
+	// messageMu guards message because Pion may invoke OnMessage concurrently
+	// with Conn/data channel closure.
+	messageMu sync.Mutex
 
 	// reliability is the reliability parameter for dataChannel.
 	// It controls how multiple segments received in the data channel is handled.
@@ -183,6 +186,9 @@ func (c *dataChannel) handleMessage(b []byte) error {
 		return fmt.Errorf("unexpected segment count on UnreliableDataChannel: %d", msg.segments)
 	}
 
+	c.messageMu.Lock()
+	defer c.messageMu.Unlock()
+
 	if c.segments > 0 && c.segments-1 != msg.segments {
 		return fmt.Errorf("invalid promised segments: expected %d, got %d", c.segments-1, msg.segments)
 	}
@@ -208,7 +214,9 @@ func (c *dataChannel) handleMessage(b []byte) error {
 func (c *dataChannel) Close() (err error) {
 	c.once.Do(func() {
 		close(c.close)
+		c.messageMu.Lock()
 		clear(c.data)
+		c.messageMu.Unlock()
 		err = c.DataChannel.Close()
 	})
 	return err


### PR DESCRIPTION
  - go-nethernet/conn_negotiation_test.go: added automated trickle and non-trickle Dialer/Listener tests.
  - go-nethernet/credentials.go: fixed stale gatherOptions docs.
  - go-nethernet/dial.go / go-nethernet/listener.go: made local description error codes offer/answer-specific.
  - go-nethernet/message.go: fixed a real race exposed by go test -race between message handling and data channel close.
