### PR TITLE
Buffer signals channel

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -302,12 +302,13 @@ func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal) {
 // receiving notifications will be returned.
 func (d Dialer) notifySignals(networkID string, signaling Signaling) (<-chan *Signal, func()) {
 	var (
-		signals     = make(chan *Signal)
-		filtered    = make(chan *Signal)
+		signals     = make(chan *Signal, 64)
+		filtered    = make(chan *Signal, 16)
 		ctx, cancel = context.WithCancel(context.Background())
+
+		once sync.Once
 	)
 	stop := signaling.Notify(signals)
-	var once sync.Once
 
 	go func() {
 		defer close(filtered)

--- a/listener.go
+++ b/listener.go
@@ -92,7 +92,7 @@ func (conf ListenConfig) Listen(signaling Signaling) (*Listener, error) {
 		closed: make(chan struct{}),
 	}
 
-	signals := make(chan *Signal)
+	signals := make(chan *Signal, 64)
 	l.stop = signaling.Notify(signals)
 	go l.listen(signals)
 


### PR DESCRIPTION
Buffer signals channel passed to `Signaling.Notify` to simplify signaling implementations.