### PR TITLE
[codex] make signaling notifications owned subscriptions

### DIFF
--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -113,9 +113,19 @@ type memorySignaling struct {
 
 	mu        sync.Mutex
 	next      int
-	notifiers map[int]chan<- *Signal
+	notifiers map[int]*memoryNotifier
 
 	stats signalStats
+}
+
+type memoryNotifier struct {
+	ch   chan *Signal
+	done chan struct{}
+	once sync.Once
+
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
 }
 
 type signalStats struct {
@@ -139,7 +149,7 @@ func newMemorySignaling(bus *memorySignalingBus, id string) *memorySignaling {
 		bus:       bus,
 		ctx:       ctx,
 		cancel:    func() { cancel(net.ErrClosed) },
-		notifiers: make(map[int]chan<- *Signal),
+		notifiers: make(map[int]*memoryNotifier),
 		stats: signalStats{
 			counts: make(map[string]int),
 		},
@@ -164,17 +174,25 @@ func (s *memorySignaling) Signal(ctx context.Context, signal *Signal) error {
 	return peer.deliver(ctx, &delivered)
 }
 
-func (s *memorySignaling) Notify(ch chan<- *Signal) func() {
+func (s *memorySignaling) Notify() (<-chan *Signal, func()) {
+	n := &memoryNotifier{
+		ch:   make(chan *Signal, 64),
+		done: make(chan struct{}),
+	}
+
 	s.mu.Lock()
 	id := s.next
 	s.next++
-	s.notifiers[id] = ch
+	s.notifiers[id] = n
 	s.mu.Unlock()
 
-	return func() {
+	return n.ch, func() {
 		s.mu.Lock()
-		delete(s.notifiers, id)
+		if s.notifiers[id] == n {
+			delete(s.notifiers, id)
+		}
 		s.mu.Unlock()
+		n.close()
 	}
 }
 
@@ -190,23 +208,55 @@ func (s *memorySignaling) close() { s.cancel() }
 
 func (s *memorySignaling) deliver(ctx context.Context, signal *Signal) error {
 	s.mu.Lock()
-	notifiers := make([]chan<- *Signal, 0, len(s.notifiers))
-	for _, ch := range s.notifiers {
-		notifiers = append(notifiers, ch)
+	notifiers := make([]*memoryNotifier, 0, len(s.notifiers))
+	for _, n := range s.notifiers {
+		notifiers = append(notifiers, n)
 	}
 	s.mu.Unlock()
 
-	for _, ch := range notifiers {
+	for _, n := range notifiers {
+		if !n.acquire() {
+			continue
+		}
 		delivered := *signal
 		select {
 		case <-ctx.Done():
+			n.release()
 			return ctx.Err()
 		case <-s.ctx.Done():
+			n.release()
 			return context.Cause(s.ctx)
-		case ch <- &delivered:
+		case <-n.done:
+		case n.ch <- &delivered:
 		}
+		n.release()
 	}
 	return nil
+}
+
+func (n *memoryNotifier) acquire() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.closed {
+		return false
+	}
+	n.wg.Add(1)
+	return true
+}
+
+func (n *memoryNotifier) release() {
+	n.wg.Done()
+}
+
+func (n *memoryNotifier) close() {
+	n.once.Do(func() {
+		n.mu.Lock()
+		n.closed = true
+		close(n.done)
+		n.mu.Unlock()
+		n.wg.Wait()
+		close(n.ch)
+	})
 }
 
 func (s *memorySignaling) recordSignal(signalType string) {

--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -17,6 +17,111 @@ func TestDialListenerNonTrickleICE(t *testing.T) {
 	testDialListener(t, true)
 }
 
+func TestConcurrentDialersShareSignaling(t *testing.T) {
+	client, server := newMemorySignalingPair("1", "2")
+	defer client.close()
+	defer server.close()
+
+	l, err := (ListenConfig{}).Listen(server)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer l.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	accepted := make(chan net.Conn, 2)
+	acceptErr := make(chan error, 1)
+	go func() {
+		for range 2 {
+			conn, err := l.Accept()
+			if err != nil {
+				acceptErr <- err
+				return
+			}
+			accepted <- conn
+		}
+	}()
+
+	type dialResult struct {
+		conn *Conn
+		err  error
+	}
+	dialed := make(chan dialResult, 2)
+	for i := range 2 {
+		go func(connectionID uint64) {
+			conn, err := (Dialer{ConnectionID: connectionID}).DialContext(ctx, server.NetworkID(), client)
+			dialed <- dialResult{conn: conn, err: err}
+		}(uint64(i + 1))
+	}
+
+	clientConns := make([]*Conn, 0, 2)
+	for range 2 {
+		select {
+		case result := <-dialed:
+			if result.err != nil {
+				t.Fatalf("DialContext() error = %v", result.err)
+			}
+			clientConns = append(clientConns, result.conn)
+			defer result.conn.Close()
+		case <-ctx.Done():
+			t.Fatalf("DialContext() timed out: %v", ctx.Err())
+		}
+	}
+
+	serverConns := make([]net.Conn, 0, 2)
+	for range 2 {
+		select {
+		case conn := <-accepted:
+			serverConns = append(serverConns, conn)
+			defer conn.Close()
+		case err := <-acceptErr:
+			t.Fatalf("Accept() error = %v", err)
+		case <-ctx.Done():
+			t.Fatalf("Accept() timed out: %v", ctx.Err())
+		}
+	}
+
+	read := make(chan string, 2)
+	readErr := make(chan error, 2)
+	for _, conn := range serverConns {
+		go func(conn net.Conn) {
+			b := make([]byte, 32)
+			n, err := conn.Read(b)
+			if err != nil {
+				readErr <- err
+				return
+			}
+			read <- string(b[:n])
+		}(conn)
+	}
+
+	payloads := []string{"first", "second"}
+	for i, conn := range clientConns {
+		if _, err := conn.Write([]byte(payloads[i])); err != nil {
+			t.Fatalf("Write(%q) error = %v", payloads[i], err)
+		}
+	}
+
+	got := make(map[string]int)
+	for range 2 {
+		select {
+		case payload := <-read:
+			got[payload]++
+		case err := <-readErr:
+			t.Fatalf("Read() error = %v", err)
+		case <-ctx.Done():
+			t.Fatalf("Read() timed out: %v", ctx.Err())
+		}
+	}
+	for _, payload := range payloads {
+		if got[payload] != 1 {
+			t.Fatalf("received %q %d times, want once; all payloads: %#v", payload, got[payload], got)
+		}
+	}
+}
+
 func testDialListener(t *testing.T, disableTrickle bool) {
 	t.Helper()
 

--- a/dial.go
+++ b/dial.go
@@ -206,7 +206,7 @@ type dialerConn struct {
 	stop func()
 }
 
-// handleClose stops receiving notifications in Notifier from Signaling for incoming signals and errors.
+// handleClose stops receiving notifications from Signaling for incoming signals and errors.
 func (d dialerConn) handleClose(*Conn) {
 	d.stop()
 }
@@ -309,13 +309,12 @@ func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal) {
 // receiving notifications will be returned.
 func (d Dialer) notifySignals(networkID string, signaling Signaling) (<-chan *Signal, func()) {
 	var (
-		signals     = make(chan *Signal, 64)
 		filtered    = make(chan *Signal, 16)
 		ctx, cancel = context.WithCancel(context.Background())
 
 		once sync.Once
 	)
-	stop := signaling.Notify(signals)
+	signals, stop := signaling.Notify()
 
 	go func() {
 		defer close(filtered)

--- a/dial_test.go
+++ b/dial_test.go
@@ -67,8 +67,14 @@ func (s *blockingErrorSignaling) Signal(ctx context.Context, signal *Signal) err
 	return ctx.Err()
 }
 
-func (*blockingErrorSignaling) Notify(chan<- *Signal) func() {
-	return func() {}
+func (*blockingErrorSignaling) Notify() (<-chan *Signal, func()) {
+	signals := make(chan *Signal)
+	var once sync.Once
+	return signals, func() {
+		once.Do(func() {
+			close(signals)
+		})
+	}
 }
 
 func (s *blockingErrorSignaling) Context() context.Context {

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -72,7 +72,7 @@ func (conf ListenConfig) Listen(addr string) (*Listener, error) {
 
 		addresses: make(map[uint64]address),
 
-		notifiers: make(map[uint32]notifier),
+		notifiers: make(map[uint32]chan *nethernet.Signal),
 		responses: make(map[uint64][]byte),
 
 		closed: make(chan struct{}),
@@ -115,7 +115,7 @@ type Listener struct {
 	// It is used as the ID for notifier channels and should not be decreased at all.
 	// notifyCount should be atomically accessed by holding a lock on notifiersMu.
 	notifyCount uint32
-	notifiers   map[uint32]notifier
+	notifiers   map[uint32]chan *nethernet.Signal
 	notifiersMu sync.RWMutex
 
 	// responses stores a map whose keys are NetherNet network IDs which value is an
@@ -127,12 +127,6 @@ type Listener struct {
 	closed chan struct{}
 	// once ensures the Listener is closed only once.
 	once sync.Once
-}
-
-// notifier holds a buffered channel for relaying incoming signals to a
-// [nethernet.Listener].
-type notifier struct {
-	ch chan *nethernet.Signal
 }
 
 // Signal sends a NetherNet signal to the corresponding address for the network ID.
@@ -171,7 +165,7 @@ func (l *Listener) Notify() (<-chan *nethernet.Signal, func()) {
 
 	l.notifiersMu.Lock()
 	i := l.notifyCount
-	l.notifiers[i] = notifier{ch: signals}
+	l.notifiers[i] = signals
 	l.notifyCount++
 	l.notifiersMu.Unlock()
 
@@ -191,12 +185,12 @@ func (l *Listener) Context() context.Context {
 // is internally assigned for the notifier and contained in the stop function returned
 // by [Listener.Notify]. It should not be called by anywhere else.
 func (l *Listener) stop(i uint32) {
-	n, ok := l.notifiers[i]
+	ch, ok := l.notifiers[i]
 	if !ok {
 		return
 	}
 	delete(l.notifiers, i)
-	close(n.ch)
+	close(ch)
 }
 
 // Credentials returns a nil *nethernet.Credentials with a nil error if the Listener is not closed.
@@ -333,9 +327,9 @@ func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
 	signal.NetworkID = strconv.FormatUint(senderID, 10)
 
 	l.notifiersMu.RLock()
-	for _, n := range l.notifiers {
+	for _, ch := range l.notifiers {
 		select {
-		case n.ch <- signal:
+		case ch <- signal:
 		default:
 			// Drop when notifier is backed up to avoid deadlocks and keep packet processing moving.
 			l.conf.Log.Debug("dropping signal due to notifier being backed up", slog.String("signal", signal.String()))

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -112,7 +112,7 @@ type Listener struct {
 	addressesMu sync.RWMutex
 
 	// notifyCount counts the total notifiers registered for the Listener.
-	// It is used as the ID for [nethernet.Notifier] and should not be decreased at all.
+	// It is used as the ID for notifier channels and should not be decreased at all.
 	// notifyCount should be atomically accessed by holding a lock on notifiersMu.
 	notifyCount uint32
 	notifiers   map[uint32]notifier
@@ -129,12 +129,10 @@ type Listener struct {
 	once sync.Once
 }
 
-// notifier holds a buffered input channel and a caller-provided output
-// channel for relaying incoming signals to a [nethernet.Listener].
+// notifier holds a buffered channel for relaying incoming signals to a
+// [nethernet.Listener].
 type notifier struct {
-	in   chan *nethernet.Signal
-	out  chan<- *nethernet.Signal
-	stop chan struct{}
+	ch chan *nethernet.Signal
 }
 
 // Signal sends a NetherNet signal to the corresponding address for the network ID.
@@ -165,43 +163,19 @@ func (l *Listener) Signal(ctx context.Context, signal *nethernet.Signal) error {
 	}
 }
 
-// Notify registers a channel to receive incoming NetherNet signals.
+// Notify registers and returns a channel to receive incoming NetherNet signals.
 //
-// The returned stop function unregisters the channel and closes it. Callers must not close
-// the channel themselves.
-func (l *Listener) Notify(signals chan<- *nethernet.Signal) (stop func()) {
+// The returned stop function unregisters the channel and closes it.
+func (l *Listener) Notify() (<-chan *nethernet.Signal, func()) {
+	signals := make(chan *nethernet.Signal, 64)
+
 	l.notifiersMu.Lock()
 	i := l.notifyCount
-	n := notifier{
-		// Buffer notifications so packet handling never blocks under lock.
-		in:   make(chan *nethernet.Signal, 64),
-		out:  signals,
-		stop: make(chan struct{}),
-	}
-	l.notifiers[i] = n
+	l.notifiers[i] = notifier{ch: signals}
 	l.notifyCount++
 	l.notifiersMu.Unlock()
 
-	go func() {
-		defer close(signals)
-		for {
-			select {
-			case <-n.stop:
-				return
-			case sig, ok := <-n.in:
-				if !ok {
-					return
-				}
-				select {
-				case <-n.stop:
-					return
-				case n.out <- sig:
-				}
-			}
-		}
-	}()
-
-	return func() {
+	return signals, func() {
 		l.notifiersMu.Lock()
 		l.stop(i)
 		l.notifiersMu.Unlock()
@@ -222,8 +196,7 @@ func (l *Listener) stop(i uint32) {
 		return
 	}
 	delete(l.notifiers, i)
-	close(n.stop)
-	close(n.in)
+	close(n.ch)
 }
 
 // Credentials returns a nil *nethernet.Credentials with a nil error if the Listener is not closed.
@@ -362,7 +335,7 @@ func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
 	l.notifiersMu.RLock()
 	for _, n := range l.notifiers {
 		select {
-		case n.in <- signal:
+		case n.ch <- signal:
 		default:
 			// Drop when notifier is backed up to avoid deadlocks and keep packet processing moving.
 			l.conf.Log.Debug("dropping signal due to notifier being backed up", slog.String("signal", signal.String()))

--- a/discovery/listener_test.go
+++ b/discovery/listener_test.go
@@ -81,7 +81,7 @@ func TestNotifyBroadcastsToMultipleSubscribers(t *testing.T) {
 	)
 	l := &Listener{
 		conf:      ListenConfig{NetworkID: localID},
-		notifiers: make(map[uint32]notifier),
+		notifiers: make(map[uint32]chan *nethernet.Signal),
 	}
 
 	first, stopFirst := l.Notify()

--- a/discovery/listener_test.go
+++ b/discovery/listener_test.go
@@ -2,7 +2,11 @@ package discovery
 
 import (
 	"net"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/df-mc/go-nethernet"
 )
 
 func TestListenAcceptsClientAddressForms(t *testing.T) {
@@ -67,5 +71,69 @@ func TestHandlePacketUpdatesAddressForKnownSender(t *testing.T) {
 	got := l.addresses[senderID]
 	if got.addr != secondAddr {
 		t.Fatalf("cached addr = %v, want %v", got.addr, secondAddr)
+	}
+}
+
+func TestNotifyBroadcastsToMultipleSubscribers(t *testing.T) {
+	const (
+		localID  uint64 = 1
+		senderID uint64 = 2
+	)
+	l := &Listener{
+		conf:      ListenConfig{NetworkID: localID},
+		notifiers: make(map[uint32]notifier),
+	}
+
+	first, stopFirst := l.Notify()
+	defer stopFirst()
+	second, stopSecond := l.Notify()
+	defer stopSecond()
+
+	signal := &nethernet.Signal{
+		Type:         nethernet.SignalTypeOffer,
+		ConnectionID: 42,
+		Data:         "offer",
+	}
+	if err := l.handleMessage(&MessagePacket{RecipientID: localID, Data: signal.String()}, senderID); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	assertSignalReceived(t, first, signal, senderID)
+	assertSignalReceived(t, second, signal, senderID)
+
+	stopFirst()
+	if _, ok := <-first; ok {
+		t.Fatal("first subscription still open after stop")
+	}
+
+	signal.ConnectionID = 43
+	if err := l.handleMessage(&MessagePacket{RecipientID: localID, Data: signal.String()}, senderID); err != nil {
+		t.Fatalf("handleMessage after stop: %v", err)
+	}
+	assertSignalReceived(t, second, signal, senderID)
+}
+
+func assertSignalReceived(t *testing.T, signals <-chan *nethernet.Signal, want *nethernet.Signal, senderID uint64) {
+	t.Helper()
+
+	select {
+	case got, ok := <-signals:
+		if !ok {
+			t.Fatal("signal channel closed")
+		}
+		if got.Type != want.Type {
+			t.Fatalf("signal type = %q, want %q", got.Type, want.Type)
+		}
+		if got.ConnectionID != want.ConnectionID {
+			t.Fatalf("connection ID = %d, want %d", got.ConnectionID, want.ConnectionID)
+		}
+		if got.Data != want.Data {
+			t.Fatalf("data = %q, want %q", got.Data, want.Data)
+		}
+		wantNetworkID := strconv.FormatUint(senderID, 10)
+		if got.NetworkID != wantNetworkID {
+			t.Fatalf("network ID = %q, want %q", got.NetworkID, wantNetworkID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for signal")
 	}
 }

--- a/listener.go
+++ b/listener.go
@@ -92,8 +92,8 @@ func (conf ListenConfig) Listen(signaling Signaling) (*Listener, error) {
 		closed: make(chan struct{}),
 	}
 
-	signals := make(chan *Signal, 64)
-	l.stop = signaling.Notify(signals)
+	signals, stop := signaling.Notify()
+	l.stop = stop
 	go l.listen(signals)
 
 	return l, nil
@@ -375,9 +375,7 @@ func (l *Listener) answererRole(role webrtc.DTLSRole) webrtc.DTLSRole {
 }
 
 // handleSignal looks up for a Conn that matches the ConnectionID and NetworkID of the Signal.
-// If a matching connection is found, it notifies the Signal by calling Conn.handleSignal. It
-// is called by the default handler in listenerNotifier.NotifySignal when the Signal type does
-// not match any specific handling cases.
+// If a matching connection is found, it notifies the Signal by calling Conn.handleSignal.
 func (l *Listener) handleSignal(signal *Signal) error {
 	addr := &Addr{
 		ConnectionID: signal.ConnectionID,

--- a/signal.go
+++ b/signal.go
@@ -17,9 +17,13 @@ type Signaling interface {
 	// the signaling server as soon as possible.
 	Signal(ctx context.Context, signal *Signal) error
 
-	// Notify registers a channel so that can be used to receive incoming signals from remote networks.
-	// It also returns a function to stop receiving signals on the channel.
-	Notify(ch chan<- *Signal) (stop func())
+	// Notify registers and returns a channel for receiving incoming signals from
+	// remote networks. Each call creates an independent subscription; incoming
+	// signals are broadcast to all active subscriptions, not load-balanced
+	// between them. The returned stop function unregisters the channel and closes
+	// it after any in-flight delivery has finished. The stop function must be
+	// safe to call multiple times.
+	Notify() (signals <-chan *Signal, stop func())
 
 	// Context returns a context for Signaling that is canceled optionally with a cause when a fatal
 	// error has occurred on the signaling server. It is used by both Dialer and Listener to notify


### PR DESCRIPTION
## What changed

This changes the `Signaling.Notify` API from a caller-owned send channel to an implementation-owned receive-only subscription:

- `Notify() (signals <-chan *Signal, stop func())`
- each call creates an independent subscription
- inbound signals are broadcast to all active subscriptions, not load-balanced
- each stop function unregisters and closes only its own channel

It also updates the NetherNet dial/listen paths, LAN discovery implementation, and tests/fakes to use the new contract.

## Why

The caller-owned channel form made close ownership ambiguous and pushed shutdown correctness onto every caller. Returning an owned receive-only channel keeps the API channel-based while making the implementation responsible for unregistering and closing safely.

## Notes

Multiple `Notify()` calls are supported. The semantics are fan-out: if two full listeners attach to the same signaling backend, both will receive the same incoming offers, so duplicate handling is intentional rather than load-balanced.

Multiple dialers can also share one signaling connection concurrently: each dial gets its own subscription and filters inbound signals by network ID and connection ID. The PR includes a regression test for two concurrent dialers using the same signaling instance.

## Validation

- `go test -run TestConcurrentDialersShareSignaling -count=10`
- `go test ./...`
- `go test -race ./...`