### PR TITLE
Keep established dials alive after signaling closes

### DIFF
--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -17,6 +17,81 @@ func TestDialListenerNonTrickleICE(t *testing.T) {
 	testDialListener(t, true)
 }
 
+func TestDialedConnSurvivesSignalingCloseAfterNegotiation(t *testing.T) {
+	client, server := newMemorySignalingPair("1", "2")
+	defer server.close()
+
+	l, err := (ListenConfig{AllowAnonymous: true}).Listen(server)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer l.Close()
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	conn, err := (Dialer{}).DialContext(ctx, server.NetworkID(), client)
+	if err != nil {
+		t.Fatalf("DialContext() error = %v", err)
+	}
+	defer conn.Close()
+
+	var serverConn net.Conn
+	select {
+	case serverConn = <-accepted:
+	case err := <-acceptErr:
+		t.Fatalf("Accept() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Accept() timed out: %v", ctx.Err())
+	}
+	defer serverConn.Close()
+
+	client.close()
+	select {
+	case <-conn.Context().Done():
+		t.Fatalf("dialed conn closed when signaling closed: %v", context.Cause(conn.Context()))
+	case <-time.After(time.Millisecond * 50):
+	}
+
+	read := make(chan string, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		b := make([]byte, 32)
+		n, err := serverConn.Read(b)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		read <- string(b[:n])
+	}()
+
+	const payload = "after-signaling-close"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatalf("Write() after signaling close error = %v", err)
+	}
+	select {
+	case got := <-read:
+		if got != payload {
+			t.Fatalf("Read() = %q, want %q", got, payload)
+		}
+	case err := <-readErr:
+		t.Fatalf("Read() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Read() timed out: %v", ctx.Err())
+	}
+}
+
 func TestConcurrentDialersShareSignaling(t *testing.T) {
 	client, server := newMemorySignalingPair("1", "2")
 	defer client.close()

--- a/dial.go
+++ b/dial.go
@@ -226,7 +226,7 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 					}
 				}
 
-				go d.handleConn(c, signals, signaling.Context())
+				go d.handleConn(c, signals)
 
 				select {
 				case <-c.ctx.Done():
@@ -343,20 +343,17 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 }
 
 // handleConn handles incoming Signals signaled from the remote connection and calls Conn.handleSignal
-// to handle them within the Conn. It returns when the Conn or Signaling context is canceled.
-func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal, signalingCtx context.Context) {
+// to handle them within the Conn. It returns when the Conn context is canceled.
+func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal) {
 	for {
 		select {
 		case <-conn.ctx.Done():
 			return
-		case <-signalingCtx.Done():
-			if err := conn.close(context.Cause(signalingCtx)); err != nil {
-				conn.log.Error("error closing conn", slog.Any("error", err))
-			}
-			return
 		case signal, ok := <-signals:
 			if !ok {
 				// Signals channel closed, connection should be closed as well
+				// when the notifier explicitly ends. Do not also watch Signaling.Context here:
+				// established WebRTC data connections may outlive the signaling transport.
 				if err := conn.Close(); err != nil {
 					conn.log.Error("error closing conn", slog.Any("error", err))
 				}


### PR DESCRIPTION
## Summary

- stop closing an established dialed Conn when the backing signaling context closes
- keep explicit notifier shutdown behavior unchanged
- add a regression test that closes signaling after negotiation and verifies data still flows

## Root Cause

After HTTP signaling support, dialed connections started watching Signaling.Context from the post-negotiation signal handling goroutine. That made an established WebRTC/SCTP data connection inherit the lifetime of the signaling transport. If signaling closed after negotiation, Conn was closed even though the data path could still be valid.

Signaling is required to negotiate the connection and exchange later candidate/error signals, but it is not the data plane. Once DialContext has returned a Conn, signaling transport closure should not by itself tear down that established connection.

## Validation

- go test . -run TestDialedConnSurvivesSignalingCloseAfterNegotiation -count=1
- go test ./...
