### PR TITLE
Harden endpoint signaling and identity handling

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -206,16 +206,16 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 				if desc.identity != nil {
 					publicKey, err := d.VerifyServerToken(ctx, desc.identity.Assertion.Token, desc.identity.IdentityProvider.Domain)
 					if err != nil {
-						d.signalError(signaling, networkID, 37)
+						d.signalError(signaling, networkID, ErrorCodeIdentityVerificationFailed)
 						return nil, fmt.Errorf("verify server identity token: %w", err)
 					}
 					if err := desc.identity.verify(desc, publicKey); err != nil {
-						d.signalError(signaling, networkID, 37)
+						d.signalError(signaling, networkID, ErrorCodeIdentityVerificationFailed)
 						return nil, fmt.Errorf("verify server identity: %w", err)
 					}
 					c.publicKey = publicKey
 				} else if !d.AllowIdentitylessServer {
-					d.signalError(signaling, networkID, 37)
+					d.signalError(signaling, networkID, ErrorCodeIdentityVerificationFailed)
 					return nil, errors.New("identityless answer SDP not allowed")
 				}
 				for _, candidate := range desc.candidates {

--- a/endpoint/client.go
+++ b/endpoint/client.go
@@ -99,9 +99,12 @@ func (c *Client) Signal(ctx context.Context, signal *nethernet.Signal) error {
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("%s %s: %s", req.Method, req.URL, resp.Status)
 		}
-		b, err := io.ReadAll(resp.Body)
+		b, err := io.ReadAll(io.LimitReader(resp.Body, maxSDPBodySize+1))
 		if err != nil {
 			return fmt.Errorf("read response body: %w", err)
+		}
+		if int64(len(b)) > maxSDPBodySize {
+			return fmt.Errorf("SDP answer exceeds %d bytes", maxSDPBodySize)
 		}
 		if len(b) == 0 {
 			return errors.New("missing SDP answer in response body")
@@ -181,7 +184,8 @@ func (c *Client) NetworkID() string {
 	return c.conf.NetworkID
 }
 
-// PongData is a no-op implementation of [nethernet.Signaling.PongData].
+// PongData is unsupported on Client because endpoint clients only dial and do
+// not receive server ping data.
 func (c *Client) PongData([]byte) {
 	panic("nethernet/endpoint: Client.PongData: unsupported")
 }

--- a/endpoint/client_test.go
+++ b/endpoint/client_test.go
@@ -2,9 +2,22 @@ package endpoint
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +26,6 @@ import (
 )
 
 func TestClientSignalDeliversSDPAnswer(t *testing.T) {
-	enableHandlerNotifyCheck = false
-	t.Cleanup(func() {
-		enableHandlerNotifyCheck = true
-	})
-
 	const answer = "v=0\r\ns=-\r\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -70,14 +78,33 @@ func TestClientSignalDeliversSDPAnswer(t *testing.T) {
 	}
 }
 
-func TestHandlerServesSDPAnswer(t *testing.T) {
-	enableHandlerNotifyCheck = false
-	t.Cleanup(func() {
-		enableHandlerNotifyCheck = true
-	})
+func TestClientSignalRejectsOversizedSDPAnswer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, strings.NewReader(strings.Repeat("x", int(maxSDPBodySize)+1)))
+	}))
+	defer server.Close()
 
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := NewClient(u)
+
+	err = client.Signal(context.Background(), &nethernet.Signal{
+		Type:         nethernet.SignalTypeOffer,
+		ConnectionID: 42,
+		NetworkID:    "123",
+		Data:         "offer",
+	})
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d bytes", maxSDPBodySize)) {
+		t.Fatalf("Signal() error = %v, want SDP size error", err)
+	}
+}
+
+func TestHandlerServesSDPAnswer(t *testing.T) {
 	const answer = "v=0\r\ns=-\r\n"
-	handler := NewHandler()
+	handler := newTestHandler()
 	stop := handler.Notify(notifierFunc(func(signal *nethernet.Signal) {
 		go func() {
 			_ = handler.Signal(context.Background(), &nethernet.Signal{
@@ -103,6 +130,88 @@ func TestHandlerServesSDPAnswer(t *testing.T) {
 	if got := result.Header.Get("Content-Type"); got != "application/sdp" {
 		t.Fatalf("content type = %q, want application/sdp", got)
 	}
+}
+
+func TestHandlerRejectsOversizedSDPOffer(t *testing.T) {
+	handler := NewHandler()
+	req := httptest.NewRequest(http.MethodPost, "/v1/join/123", strings.NewReader(strings.Repeat("x", int(maxSDPBodySize)+1)))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	if result.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", result.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestServeTLSCloseCancelsContextWithoutServerClosedCause(t *testing.T) {
+	certFile, keyFile := writeTestCertificate(t)
+	handler, err := HandlerConfig{}.ServeTLS("127.0.0.1:0", certFile, keyFile)
+	if err != nil {
+		t.Fatalf("ServeTLS() error = %v", err)
+	}
+
+	if err := handler.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case <-handler.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handler context cancellation")
+	}
+	if err := context.Cause(handler.Context()); errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("context cause = %v, want clean close cause", err)
+	} else if !errors.Is(err, context.Canceled) {
+		t.Fatalf("context cause = %v, want %v", err, context.Canceled)
+	}
+}
+
+func newTestHandler() *Handler {
+	handler := NewHandler()
+	handler.disableNotifyTypeCheck = true
+	return handler
+}
+
+func writeTestCertificate(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, err := x509.CreateCertificate(cryptorand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
+		t.Fatalf("write certificate: %v", err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certFile, keyFile
 }
 
 type notifierFunc func(*nethernet.Signal)

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -2,7 +2,9 @@ package endpoint
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -93,18 +95,36 @@ func (conf HandlerConfig) ServeTLS(address string, certFile, keyFile string) (*H
 	h := conf.New()
 	var cancel context.CancelCauseFunc
 	h.ctx, cancel = context.WithCancelCause(context.Background())
-	server := &http.Server{Handler: h}
+	server := &http.Server{
+		Handler:           h,
+		ReadHeaderTimeout: serveTLSReadHeaderTimeout,
+		ReadTimeout:       serveTLSReadTimeout,
+		IdleTimeout:       serveTLSIdleTimeout,
+	}
 	// Call [http.Server.Serve] in a goroutine since it is a blocking method.
 	go func() {
-		if err := server.Serve(l); err != nil {
+		if err := server.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			cancel(err)
 		}
 	}()
 	h.closeFunc = func() error {
-		return server.Close()
+		err := server.Close()
+		cancel(nil)
+		return err
 	}
 	return h, nil
 }
+
+const (
+	// maxSDPBodySize caps HTTP SDP offer and answer bodies at 1 MiB.
+	maxSDPBodySize int64 = 1 << 20
+	// serveTLSReadHeaderTimeout bounds how long a client may spend sending request headers.
+	serveTLSReadHeaderTimeout = 5 * time.Second
+	// serveTLSReadTimeout bounds how long a client may spend sending a complete request.
+	serveTLSReadTimeout = 10 * time.Second
+	// serveTLSIdleTimeout bounds how long an idle keep-alive connection may remain open.
+	serveTLSIdleTimeout = 30 * time.Second
+)
 
 // ServeTLS is a utility method that set-ups an HTTP/TLS server on the specified
 // address using the TLS certificate and key file. It is equivalent of
@@ -143,6 +163,9 @@ type Handler struct {
 	notifier   nethernet.Notifier
 	notifierID uint64
 	notifierMu sync.RWMutex
+
+	// disableNotifyTypeCheck permits tests to register lightweight Notifier stubs.
+	disableNotifyTypeCheck bool
 }
 
 // Signal delivers a signal to the pending negotiation identified by the
@@ -169,17 +192,12 @@ func (h *Handler) Signal(ctx context.Context, signal *nethernet.Signal) error {
 	}
 }
 
-// enableHandlerNotifyCheck determines whether to ensure that the [nethernet.Notifier]
-// passed to [Handler.Notify] is [nethernet.Listener]. It is used for testing.
-var enableHandlerNotifyCheck = true
-
 // Notify registers n to receive incoming HTTP endpoint offers.
 func (h *Handler) Notify(n nethernet.Notifier) (stop func()) {
 	if n == nil {
 		panic("nethernet/endpoint: Handler.Notify: nil Notifier")
 	}
-	//noinspection GoBoolExpressions enableHandlerNotifyCheck can be false in testing environment.
-	if _, ok := n.(*nethernet.Listener); enableHandlerNotifyCheck && !ok {
+	if _, ok := n.(*nethernet.Listener); !h.disableNotifyTypeCheck && !ok {
 		panic(fmt.Sprintf("nethernet/endpoint: Handler can only be used with *nethernet.Listener: %T", n))
 	}
 	h.notifierMu.Lock()
@@ -265,9 +283,21 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 	}
 	log = log.With("networkID", networkID)
 
+	req.Body = http.MaxBytesReader(w, req.Body, maxSDPBodySize)
 	b, err := io.ReadAll(req.Body)
-	if err != nil || len(b) == 0 {
-		log.Error("error reading response body", "error", err, "contentLength", len(b))
+	if err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			log.Error("SDP offer is too large", "limit", maxBytesError.Limit)
+			writeText(w, http.StatusRequestEntityTooLarge, "SDP offer is too large")
+			return
+		}
+		log.Error("error reading request body", "error", err)
+		writeText(w, http.StatusBadRequest, "Missing SDP offer in request body")
+		return
+	}
+	if len(b) == 0 {
+		log.Error("missing SDP offer in request body")
 		writeText(w, http.StatusBadRequest, "Missing SDP offer in request body")
 		return
 	}
@@ -277,7 +307,12 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 
 	signal, err := h.negotiate(ctx, networkID, string(b))
 	if err != nil {
-		log.Error("error negotiating", slog.String("offer", string(b)), slog.Any("error", err))
+		offerHash := sha256.Sum256(b)
+		log.Error("error negotiating",
+			slog.Int("offerSize", len(b)),
+			slog.String("offerSHA256", hex.EncodeToString(offerHash[:])),
+			slog.Any("error", err),
+		)
 		if errors.Is(err, context.DeadlineExceeded) {
 			writeText(w, http.StatusBadGateway, "Timed out waiting for answer")
 			return

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -2,9 +2,7 @@ package endpoint
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -307,10 +305,9 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 
 	signal, err := h.negotiate(ctx, networkID, string(b))
 	if err != nil {
-		offerHash := sha256.Sum256(b)
 		log.Error("error negotiating",
 			slog.Int("offerSize", len(b)),
-			slog.String("offerSHA256", hex.EncodeToString(offerHash[:])),
+			slog.String("offer", string(b)),
 			slog.Any("error", err),
 		)
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/identity.go
+++ b/identity.go
@@ -39,7 +39,7 @@ type Identity struct {
 }
 
 // sign signs the DTLS fingerprints included in the given local description using
-// the [Identity.PublicKey], and returns an identityData that can be embedded
+// the [Identity.PrivateKey], and returns an identityData that can be embedded
 // to the description.
 func (i Identity) sign(desc *description) error {
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: i.PrivateKey}, nil)
@@ -104,13 +104,17 @@ func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 // Identity contains a self-signed JWT token with a 1-minute expiration time and the public key
 // embedded as the 'cpk' claim.
 func GenerateServerIdentity(privateKey *ecdsa.PrivateKey, domain string) (*Identity, error) {
+	encodedPublicKey, err := encodePublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("encode public key: %w", err)
+	}
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, &jose.SignerOptions{
 		ExtraHeaders: map[jose.HeaderKey]any{
 			// On Bedrock Dedicated Servers, just like the JWT token included in the
 			// ServerToClientHandshake packet, this JWT token also includes the public
 			// key in the 'x5u' claim.
 			// Though it is not strictly required, we do this to match vanilla behavior.
-			"x5u": encodePublicKey(&privateKey.PublicKey),
+			"x5u": encodedPublicKey,
 		},
 	})
 	if err != nil {
@@ -144,10 +148,14 @@ type tokenClaims struct {
 // It performs additional handling for encoding the cpk claim in base64.
 func (c tokenClaims) MarshalJSON() ([]byte, error) {
 	type Alias tokenClaims
+	publicKey, err := encodePublicKey(c.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("encode cpk: %w", err)
+	}
 	return json.Marshal(struct {
 		Alias
 		PublicKey string `json:"cpk"`
-	}{Alias: (Alias)(c), PublicKey: encodePublicKey(c.PublicKey)})
+	}{Alias: (Alias)(c), PublicKey: publicKey})
 }
 
 // UnmarshalJSON implements [json.Unmarshaler] for tokenClaims.
@@ -275,12 +283,15 @@ func (a *identityAssertion) UnmarshalJSON(b []byte) error {
 }
 
 // encodePublicKey encodes an ECDSA public key given by the user to a base64-encoded string.
-func encodePublicKey(publicKey *ecdsa.PublicKey) string {
+func encodePublicKey(publicKey *ecdsa.PublicKey) (string, error) {
+	if publicKey == nil {
+		return "", errors.New("nethernet: public key is nil")
+	}
 	b, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
-		panic(fmt.Sprintf("error encoding public key: %s", err))
+		return "", fmt.Errorf("marshal PKIX public key: %w", err)
 	}
-	return base64.StdEncoding.EncodeToString(b)
+	return base64.StdEncoding.EncodeToString(b), nil
 }
 
 // parsePublicKey decodes a base64-encoded string as an ECDSA public key.

--- a/identity_test.go
+++ b/identity_test.go
@@ -1,0 +1,109 @@
+package nethernet
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/pion/webrtc/v4"
+)
+
+func TestIdentitySignVerifyRoundTrip(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	identity, err := GenerateServerIdentity(privateKey, "self")
+	if err != nil {
+		t.Fatalf("GenerateServerIdentity() error = %v", err)
+	}
+	publicKey, err := claimPublicKey(identity.Token, true)
+	if err != nil {
+		t.Fatalf("claimPublicKey() error = %v", err)
+	}
+
+	desc := newIdentityTestDescription()
+	if err := identity.sign(desc); err != nil {
+		t.Fatalf("sign() error = %v", err)
+	}
+	if err := desc.identity.verify(desc, publicKey); err != nil {
+		t.Fatalf("verify() error = %v", err)
+	}
+}
+
+func TestIdentityVerifyRejectsTamperedFingerprint(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	identity, err := GenerateServerIdentity(privateKey, "self")
+	if err != nil {
+		t.Fatalf("GenerateServerIdentity() error = %v", err)
+	}
+	publicKey, err := claimPublicKey(identity.Token, true)
+	if err != nil {
+		t.Fatalf("claimPublicKey() error = %v", err)
+	}
+
+	desc := newIdentityTestDescription()
+	if err := identity.sign(desc); err != nil {
+		t.Fatalf("sign() error = %v", err)
+	}
+	desc.dtls.Fingerprints[0].Value = "FF:FF:FF:FF"
+	if err := desc.identity.verify(desc, publicKey); err == nil {
+		t.Fatal("verify() succeeded for tampered fingerprint")
+	}
+}
+
+func TestClaimPublicKeyRejectsExpiredToken(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	token, err := newIdentityTestToken(privateKey, time.Now().Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestToken() error = %v", err)
+	}
+	if _, err := claimPublicKey(token, true); err == nil {
+		t.Fatal("claimPublicKey() succeeded for expired token")
+	}
+}
+
+func TestTokenClaimsMarshalRejectsNilPublicKey(t *testing.T) {
+	_, err := json.Marshal(tokenClaims{})
+	if err == nil || !strings.Contains(err.Error(), "public key is nil") {
+		t.Fatalf("MarshalJSON() error = %v, want nil public key error", err)
+	}
+}
+
+func newIdentityTestDescription() *description {
+	return &description{
+		dtls: webrtc.DTLSParameters{
+			Fingerprints: []webrtc.DTLSFingerprint{{
+				Algorithm: "sha-256",
+				Value:     "00:11:22:33:44:55:66:77",
+			}},
+		},
+	}
+}
+
+func newIdentityTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), cryptorand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	return privateKey
+}
+
+func newIdentityTestToken(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (string, error) {
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, nil)
+	if err != nil {
+		return "", err
+	}
+	issuedAt := expiresAt.Add(-time.Minute)
+	return jwt.Signed(signer).Claims(tokenClaims{
+		Claims: jwt.Claims{
+			Expiry:   jwt.NewNumericDate(expiresAt),
+			IssuedAt: jwt.NewNumericDate(issuedAt),
+		},
+		PublicKey: &privateKey.PublicKey,
+	}).Serialize()
+}

--- a/listener.go
+++ b/listener.go
@@ -397,21 +397,25 @@ func (l *Listener) handleOffer(signal *Signal) error {
 	if desc.identity != nil {
 		publicKey, err := l.conf.VerifyClientToken(ctx, desc.identity.Assertion.Token)
 		if err != nil {
-			return wrapSignalError(fmt.Errorf("verify client token: %w", err), 37)
+			return wrapSignalError(fmt.Errorf("verify client token: %w", err), ErrorCodeIdentityVerificationFailed)
 		}
 		if err := desc.identity.verify(desc, publicKey); err != nil {
-			return wrapSignalError(fmt.Errorf("verify identity assertion: %w", err), 37)
+			return wrapSignalError(fmt.Errorf("verify identity assertion: %w", err), ErrorCodeIdentityVerificationFailed)
 		}
 		c.publicKey = publicKey
 	} else if !l.conf.AllowAnonymous {
-		return wrapSignalError(errors.New("nethernet: anonymous identity not allowed"), 37)
+		l.conf.Log.Warn("rejecting anonymous identity because AllowAnonymous is false",
+			slog.Uint64("connectionID", signal.ConnectionID),
+			slog.String("networkID", signal.NetworkID),
+		)
+		return wrapSignalError(errors.New("nethernet: anonymous identity not allowed"), ErrorCodeIdentityVerificationFailed)
 	}
 	identity, err := l.conf.IssueServerIdentity(ctx)
 	if err != nil {
-		return wrapSignalError(fmt.Errorf("issue server identity: %w", err), 37)
+		return wrapSignalError(fmt.Errorf("issue server identity: %w", err), ErrorCodeIdentityVerificationFailed)
 	}
 	if err := identity.sign(c.description); err != nil {
-		return wrapSignalError(fmt.Errorf("generate identity assertion: %w", err), 37)
+		return wrapSignalError(fmt.Errorf("generate identity assertion: %w", err), ErrorCodeIdentityVerificationFailed)
 	}
 
 	// Register a callback function immediately since the remote peer

--- a/signal.go
+++ b/signal.go
@@ -222,4 +222,8 @@ const (
 	ErrorCodeNoSignalingChannel
 	ErrorCodeNotLoggedIn
 	ErrorCodeSignalingFailedToSend
+
+	// ErrorCodeIdentityVerificationFailed reports that the remote identity token
+	// or its DTLS fingerprint assertion failed validation.
+	ErrorCodeIdentityVerificationFailed = 37
 )


### PR DESCRIPTION
## Summary

- add timeouts to the ServeTLS HTTP server and keep normal shutdown from recording http.ErrServerClosed as the handler context cause
- bound SDP request and response body reads, and stop logging full SDP offers on negotiation failures
- replace identity error code 37 with ErrorCodeIdentityVerificationFailed
- make endpoint handler tests avoid the package-global notify check toggle
- add focused identity tests for sign/verify, tampered fingerprints, expired tokens, and nil cpk marshal errors

## Notes

This intentionally does not redesign endpoint.Handler's Signaling semantics or change the identity verification trust model. Those are broader API/design decisions and should stay separate from this hardening cleanup.

The SDP body limit is 1 MiB to avoid clipping identity-bearing or bundled-candidate SDP while still bounding untrusted HTTP input.

## Validation

- go test . -run 'TestIdentity|TestClaimPublicKey|TestTokenClaims' -count=1
- go test ./endpoint -run 'TestClientSignal|TestHandler|TestServeTLS' -count=1
- go test ./...
- go vet ./...
- go test -race ./endpoint
- git diff --check
