### PR TITLE
Document endpoint anonymous identity mode

### DIFF
--- a/examples/endpoint/client/main.go
+++ b/examples/endpoint/client/main.go
@@ -20,8 +20,8 @@ func init() {
 }
 
 // main is a program that demonstrates a client connecting to the server over NetherNet
-// using HTTP endpoint as the signaling method. The server must be running in offline mode
-// since it does not perform identity assertion.
+// using HTTP endpoint as the signaling method. This example does not configure a
+// client identity, so the server must allow anonymous/offline connections.
 func main() {
 	address := flag.Arg(0)
 	if address == "" {

--- a/examples/endpoint/server/main.go
+++ b/examples/endpoint/server/main.go
@@ -50,7 +50,12 @@ func main() {
 	}
 
 	server := endpoint.NewHandler()
-	l, err := nethernet.ListenConfig{DisableTrickleICE: true}.Listen(server)
+	l, err := nethernet.ListenConfig{
+		// The example client does not send an identity assertion, so this
+		// endpoint server opts into anonymous/offline connections explicitly.
+		AllowAnonymous:    true,
+		DisableTrickleICE: true,
+	}.Listen(server)
 	if err != nil {
 		panic(fmt.Sprintf("error listening on NetherNet: %s", err))
 	}

--- a/listener.go
+++ b/listener.go
@@ -75,18 +75,21 @@ type ListenConfig struct {
 	// verification using the public keys exposed by Minecraft's authorization service,
 	// as this library does not provide access to that endpoint.
 	//
-	// This is still safe because the Minecraft protocol layer verifies the same
-	// token present in the Login packet's connection request and checks that the
-	// same public key was used in the 'cpk' claim. Even if an attacker replayed
-	// a token, they could not replace the 'cpk' claim without invalidating the JWT
-	// signature, and therefore would be unable to produce a valid signature for the DTLS
-	// fingerprint assertion.
+	// The default verifier only binds the SDP identity assertion to the public
+	// key in the token. It is appropriate for Bedrock integrations only when the
+	// Minecraft protocol layer also verifies the Login packet token and checks
+	// that the same public key was used in its 'cpk' claim. Servers that rely on
+	// NetherNet identity alone should provide a verifier that validates token
+	// issuance.
 	VerifyClientToken func(ctx context.Context, token string) (*ecdsa.PublicKey, error)
 
 	// AllowAnonymous determines whether SDP offers without an 'a=identity'
 	// attribute are accepted.
 	// When set to false, all incoming connections must provide a valid identity
 	// assertion. When set to true, unauthenticated peers are allowed to connect.
+	//
+	// The zero value is false. Set this explicitly for offline/custom clients
+	// that do not send identity assertions.
 	//
 	// This may be useful for implementing offline-mode servers, but it removes
 	// the identity binding normally provided by NetherNet and may allow replay


### PR DESCRIPTION
## Summary

- make the HTTP endpoint server example explicitly allow anonymous/offline offers so it interoperates with the identityless example client
- clarify the endpoint client example comment around anonymous/offline server requirements
- tighten ListenConfig docs for default VerifyClientToken behavior and the zero-value AllowAnonymous default

## Notes

This does not change identity verification behavior. It only documents the existing contract: the default VerifyClientToken binds the SDP identity assertion to the token cpk, and Bedrock integrations still need the Minecraft protocol layer to verify the Login packet token.

## Validation

- go test ./...
- go vet ./...
- git diff --check
