### PR TITLE
Report endpoint offer admission failures

### DIFF
--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -313,7 +313,7 @@ func (s *memorySignaling) deliver(ctx context.Context, signal *Signal) error {
 			return context.Cause(s.ctx)
 		default:
 		}
-		n.NotifySignal(&delivered)
+		_ = n.NotifySignal(&delivered)
 	}
 	return nil
 }

--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -17,6 +17,81 @@ func TestDialListenerNonTrickleICE(t *testing.T) {
 	testDialListener(t, true)
 }
 
+func TestDialedConnSurvivesSignalingCloseAfterNegotiation(t *testing.T) {
+	client, server := newMemorySignalingPair("1", "2")
+	defer server.close()
+
+	l, err := (ListenConfig{AllowAnonymous: true}).Listen(server)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer l.Close()
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	conn, err := (Dialer{}).DialContext(ctx, server.NetworkID(), client)
+	if err != nil {
+		t.Fatalf("DialContext() error = %v", err)
+	}
+	defer conn.Close()
+
+	var serverConn net.Conn
+	select {
+	case serverConn = <-accepted:
+	case err := <-acceptErr:
+		t.Fatalf("Accept() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Accept() timed out: %v", ctx.Err())
+	}
+	defer serverConn.Close()
+
+	client.close()
+	select {
+	case <-conn.Context().Done():
+		t.Fatalf("dialed conn closed when signaling closed: %v", context.Cause(conn.Context()))
+	case <-time.After(time.Millisecond * 50):
+	}
+
+	read := make(chan string, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		b := make([]byte, 32)
+		n, err := serverConn.Read(b)
+		if err != nil {
+			readErr <- err
+			return
+		}
+		read <- string(b[:n])
+	}()
+
+	const payload = "after-signaling-close"
+	if _, err := conn.Write([]byte(payload)); err != nil {
+		t.Fatalf("Write() after signaling close error = %v", err)
+	}
+	select {
+	case got := <-read:
+		if got != payload {
+			t.Fatalf("Read() = %q, want %q", got, payload)
+		}
+	case err := <-readErr:
+		t.Fatalf("Read() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Read() timed out: %v", ctx.Err())
+	}
+}
+
 func TestConcurrentDialersShareSignaling(t *testing.T) {
 	client, server := newMemorySignalingPair("1", "2")
 	defer client.close()

--- a/dial.go
+++ b/dial.go
@@ -206,16 +206,16 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 				if desc.identity != nil {
 					publicKey, err := d.VerifyServerToken(ctx, desc.identity.Assertion.Token, desc.identity.IdentityProvider.Domain)
 					if err != nil {
-						d.signalError(signaling, networkID, 37)
+						d.signalError(signaling, networkID, ErrorCodeIdentityVerificationFailed)
 						return nil, fmt.Errorf("verify server identity token: %w", err)
 					}
 					if err := desc.identity.verify(desc, publicKey); err != nil {
-						d.signalError(signaling, networkID, 37)
+						d.signalError(signaling, networkID, ErrorCodeIdentityVerificationFailed)
 						return nil, fmt.Errorf("verify server identity: %w", err)
 					}
 					c.publicKey = publicKey
 				} else if !d.AllowIdentitylessServer {
-					d.signalError(signaling, networkID, 37)
+					d.signalError(signaling, networkID, ErrorCodeIdentityVerificationFailed)
 					return nil, errors.New("identityless answer SDP not allowed")
 				}
 				for _, candidate := range desc.candidates {

--- a/dial.go
+++ b/dial.go
@@ -226,7 +226,7 @@ func (d Dialer) DialContext(ctx context.Context, networkID string, signaling Sig
 					}
 				}
 
-				go d.handleConn(c, signals, signaling.Context())
+				go d.handleConn(c, signals)
 
 				select {
 				case <-c.ctx.Done():
@@ -343,20 +343,17 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 }
 
 // handleConn handles incoming Signals signaled from the remote connection and calls Conn.handleSignal
-// to handle them within the Conn. It returns when the Conn or Signaling context is canceled.
-func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal, signalingCtx context.Context) {
+// to handle them within the Conn. It returns when the Conn context is canceled.
+func (d Dialer) handleConn(conn *Conn, signals <-chan *Signal) {
 	for {
 		select {
 		case <-conn.ctx.Done():
 			return
-		case <-signalingCtx.Done():
-			if err := conn.close(context.Cause(signalingCtx)); err != nil {
-				conn.log.Error("error closing conn", slog.Any("error", err))
-			}
-			return
 		case signal, ok := <-signals:
 			if !ok {
 				// Signals channel closed, connection should be closed as well
+				// when the notifier explicitly ends. Do not also watch Signaling.Context here:
+				// established WebRTC data connections may outlive the signaling transport.
 				if err := conn.Close(); err != nil {
 					conn.log.Error("error closing conn", slog.Any("error", err))
 				}

--- a/dial.go
+++ b/dial.go
@@ -414,15 +414,17 @@ type dialerNotifier struct {
 }
 
 // NotifySignal notifies an incoming Signal received from the Signaling implementation.
-func (d *dialerNotifier) NotifySignal(signal *Signal) {
+func (d *dialerNotifier) NotifySignal(signal *Signal) bool {
 	if signal.ConnectionID != d.ConnectionID || signal.NetworkID != d.networkID {
-		return
+		return false
 	}
 	select {
 	case d.signals <- signal:
+		return true
 	case <-d.ctx.Done():
-		return
+		return false
 	default:
 		d.Log.Warn("dropping signal because channel buffer is full", slog.Any("signal", signal))
+		return false
 	}
 }

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -323,7 +323,7 @@ func (l *Listener) handleMessage(pk *MessagePacket, senderID uint64) error {
 	}
 	l.notifiersMu.RUnlock()
 	for _, n := range notifiers {
-		n.NotifySignal(signal)
+		_ = n.NotifySignal(signal)
 	}
 
 	return nil

--- a/discovery/listener_test.go
+++ b/discovery/listener_test.go
@@ -120,9 +120,10 @@ func newSignalRecorder() *signalRecorder {
 	return &signalRecorder{signals: make(chan *nethernet.Signal, 4)}
 }
 
-func (r *signalRecorder) NotifySignal(signal *nethernet.Signal) {
+func (r *signalRecorder) NotifySignal(signal *nethernet.Signal) bool {
 	delivered := *signal
 	r.signals <- &delivered
+	return true
 }
 
 func assertSignalReceived(t *testing.T, recorder *signalRecorder, want *nethernet.Signal, senderID uint64) {

--- a/endpoint/client.go
+++ b/endpoint/client.go
@@ -99,9 +99,12 @@ func (c *Client) Signal(ctx context.Context, signal *nethernet.Signal) error {
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("%s %s: %s", req.Method, req.URL, resp.Status)
 		}
-		b, err := io.ReadAll(resp.Body)
+		b, err := io.ReadAll(io.LimitReader(resp.Body, maxSDPBodySize+1))
 		if err != nil {
 			return fmt.Errorf("read response body: %w", err)
+		}
+		if int64(len(b)) > maxSDPBodySize {
+			return fmt.Errorf("SDP answer exceeds %d bytes", maxSDPBodySize)
 		}
 		if len(b) == 0 {
 			return errors.New("missing SDP answer in response body")
@@ -181,7 +184,8 @@ func (c *Client) NetworkID() string {
 	return c.conf.NetworkID
 }
 
-// PongData is a no-op implementation of [nethernet.Signaling.PongData].
+// PongData is unsupported on Client because endpoint clients only dial and do
+// not receive server ping data.
 func (c *Client) PongData([]byte) {
 	panic("nethernet/endpoint: Client.PongData: unsupported")
 }

--- a/endpoint/client.go
+++ b/endpoint/client.go
@@ -33,7 +33,7 @@ type ClientConfig struct {
 	Logger *slog.Logger
 
 	// NetworkID is the identifier assigned to this Handler.
-	// It is used only for identifying Client and is never transmitted to clients.
+	// It is included to the URL path of requests sent to servers.
 	// If empty, a random uint64 is generated and used.
 	NetworkID string
 }
@@ -184,8 +184,8 @@ func (c *Client) Credentials(ctx context.Context) (*nethernet.Credentials, error
 }
 
 // NetworkID returns a network ID assigned for this Client.
-// This is never transmitted to clients and is currently only
-// used for locally identifying this Client.
+// It is included to the URL path of requests sent to servers.
+// Callers can specify this value from [ClientConfig.NetworkID].
 func (c *Client) NetworkID() string {
 	return c.conf.NetworkID
 }

--- a/endpoint/client.go
+++ b/endpoint/client.go
@@ -195,6 +195,6 @@ func (c *Client) notifySignal(signal *nethernet.Signal) {
 	}
 	c.notifiersMu.RUnlock()
 	for _, n := range notifiers {
-		n.NotifySignal(signal)
+		_ = n.NotifySignal(signal)
 	}
 }

--- a/endpoint/client.go
+++ b/endpoint/client.go
@@ -40,7 +40,7 @@ type ClientConfig struct {
 
 // New returns a new [Client] from the configuration.
 // The resulting [Client] can be passed to [nethernet.Dialer.DialContext].
-func (conf ClientConfig) New(u *url.URL) *Client {
+func (conf ClientConfig) New() *Client {
 	if conf.HTTPClient == nil {
 		conf.HTTPClient = http.DefaultClient
 	}
@@ -51,7 +51,6 @@ func (conf ClientConfig) New(u *url.URL) *Client {
 		conf.NetworkID = strconv.FormatUint(rand.Uint64(), 10)
 	}
 	return &Client{
-		url:  u,
 		conf: conf,
 
 		notifiers: make(map[uint32]nethernet.Notifier),
@@ -60,14 +59,13 @@ func (conf ClientConfig) New(u *url.URL) *Client {
 
 // NewClient creates a new [Client] with the default ClientConfig.
 // It is equivalent to calling ClientConfig{}.New().
-func NewClient(u *url.URL) *Client {
+func NewClient() *Client {
 	var conf ClientConfig
-	return conf.New(u)
+	return conf.New()
 }
 
 // Client implements [nethernet.Signaling] using the HTTP endpoints exposed by a NetherNet server.
 type Client struct {
-	url  *url.URL
 	conf ClientConfig
 
 	notifiers   map[uint32]nethernet.Notifier
@@ -80,9 +78,17 @@ type Client struct {
 // Only [nethernet.SignalTypeOffer] is supported. The returned SDP answer is delivered
 // to the Dialers registered to this Client.
 func (c *Client) Signal(ctx context.Context, signal *nethernet.Signal) error {
+	u, err := url.Parse(signal.NetworkID)
+	if err != nil {
+		return fmt.Errorf("parse network ID as URL: %w", err)
+	}
+	if (u.Scheme != "https" && u.Scheme != "http") || u.Path != "" || u.Port() == "" {
+		return fmt.Errorf("network ID must be a HTTP/HTTPS URL with port: %s", signal.NetworkID)
+	}
+
 	switch signal.Type {
 	case nethernet.SignalTypeOffer:
-		requestURL := c.url.JoinPath("/v1/join", signal.NetworkID).String()
+		requestURL := u.JoinPath("/v1/join", c.conf.NetworkID).String()
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(signal.Data))
 		if err != nil {
 			return fmt.Errorf("make request: %w", err)

--- a/endpoint/client_test.go
+++ b/endpoint/client_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -119,6 +120,26 @@ func TestHandlerServesSDPAnswer(t *testing.T) {
 	}
 	if got := result.Header.Get("Content-Type"); got != "application/sdp" {
 		t.Fatalf("content type = %q, want application/sdp", got)
+	}
+}
+
+func TestServeTLSCloseCancelsContextWithoutServerClosedCause(t *testing.T) {
+	certFile, keyFile := writeTestCertificate(t)
+	handler, err := HandlerConfig{}.ServeTLS("127.0.0.1:0", certFile, keyFile)
+	if err != nil {
+		t.Fatalf("ServeTLS() error = %v", err)
+	}
+
+	if err := handler.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case <-handler.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handler context cancellation")
+	}
+	if err := context.Cause(handler.Context()); !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("context cause = %v, want http.ErrServerClosed", err)
 	}
 }
 

--- a/endpoint/client_test.go
+++ b/endpoint/client_test.go
@@ -8,14 +8,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io"
 	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,11 +37,7 @@ func TestClientSignalDeliversSDPAnswer(t *testing.T) {
 	}))
 	defer server.Close()
 
-	u, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatalf("parse server URL: %v", err)
-	}
-	client := NewClient(u)
+	client := ClientConfig{NetworkID: "123"}.New()
 	signals := make(chan *nethernet.Signal, 1)
 	stop := client.Notify(notifierFunc(func(signal *nethernet.Signal) {
 		signals <- signal
@@ -53,7 +47,7 @@ func TestClientSignalDeliversSDPAnswer(t *testing.T) {
 	if err := client.Signal(context.Background(), &nethernet.Signal{
 		Type:         nethernet.SignalTypeOffer,
 		ConnectionID: 42,
-		NetworkID:    "123",
+		NetworkID:    server.URL,
 		Data:         "offer",
 	}); err != nil {
 		t.Fatalf("Signal() error = %v", err)
@@ -67,8 +61,8 @@ func TestClientSignalDeliversSDPAnswer(t *testing.T) {
 		if signal.ConnectionID != 42 {
 			t.Fatalf("connection ID = %d, want 42", signal.ConnectionID)
 		}
-		if signal.NetworkID != "123" {
-			t.Fatalf("network ID = %q, want 123", signal.NetworkID)
+		if signal.NetworkID != server.URL {
+			t.Fatalf("network ID = %q, want %q", signal.NetworkID, server.URL)
 		}
 		if signal.Data != answer {
 			t.Fatalf("data = %q, want %q", signal.Data, answer)
@@ -85,16 +79,12 @@ func TestClientSignalRejectsOversizedSDPAnswer(t *testing.T) {
 	}))
 	defer server.Close()
 
-	u, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatalf("parse server URL: %v", err)
-	}
-	client := NewClient(u)
+	client := NewClient()
 
-	err = client.Signal(context.Background(), &nethernet.Signal{
+	err := client.Signal(context.Background(), &nethernet.Signal{
 		Type:         nethernet.SignalTypeOffer,
 		ConnectionID: 42,
-		NetworkID:    "123",
+		NetworkID:    server.URL,
 		Data:         "offer",
 	})
 	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d bytes", maxSDPBodySize)) {
@@ -143,28 +133,6 @@ func TestHandlerRejectsOversizedSDPOffer(t *testing.T) {
 
 	if result.StatusCode != http.StatusRequestEntityTooLarge {
 		t.Fatalf("status = %d, want %d", result.StatusCode, http.StatusRequestEntityTooLarge)
-	}
-}
-
-func TestServeTLSCloseCancelsContextWithoutServerClosedCause(t *testing.T) {
-	certFile, keyFile := writeTestCertificate(t)
-	handler, err := HandlerConfig{}.ServeTLS("127.0.0.1:0", certFile, keyFile)
-	if err != nil {
-		t.Fatalf("ServeTLS() error = %v", err)
-	}
-
-	if err := handler.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
-	}
-	select {
-	case <-handler.Context().Done():
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for handler context cancellation")
-	}
-	if err := context.Cause(handler.Context()); errors.Is(err, http.ErrServerClosed) {
-		t.Fatalf("context cause = %v, want clean close cause", err)
-	} else if !errors.Is(err, context.Canceled) {
-		t.Fatalf("context cause = %v, want %v", err, context.Canceled)
 	}
 }
 

--- a/endpoint/client_test.go
+++ b/endpoint/client_test.go
@@ -2,9 +2,22 @@ package endpoint
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +26,6 @@ import (
 )
 
 func TestClientSignalDeliversSDPAnswer(t *testing.T) {
-	enableHandlerNotifyCheck = false
-	t.Cleanup(func() {
-		enableHandlerNotifyCheck = true
-	})
-
 	const answer = "v=0\r\ns=-\r\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -70,14 +78,33 @@ func TestClientSignalDeliversSDPAnswer(t *testing.T) {
 	}
 }
 
-func TestHandlerServesSDPAnswer(t *testing.T) {
-	enableHandlerNotifyCheck = false
-	t.Cleanup(func() {
-		enableHandlerNotifyCheck = true
-	})
+func TestClientSignalRejectsOversizedSDPAnswer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, strings.NewReader(strings.Repeat("x", int(maxSDPBodySize)+1)))
+	}))
+	defer server.Close()
 
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := NewClient(u)
+
+	err = client.Signal(context.Background(), &nethernet.Signal{
+		Type:         nethernet.SignalTypeOffer,
+		ConnectionID: 42,
+		NetworkID:    "123",
+		Data:         "offer",
+	})
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds %d bytes", maxSDPBodySize)) {
+		t.Fatalf("Signal() error = %v, want SDP size error", err)
+	}
+}
+
+func TestHandlerServesSDPAnswer(t *testing.T) {
 	const answer = "v=0\r\ns=-\r\n"
-	handler := NewHandler()
+	handler := newTestHandler()
 	stop := handler.Notify(notifierFunc(func(signal *nethernet.Signal) {
 		go func() {
 			_ = handler.Signal(context.Background(), &nethernet.Signal{
@@ -103,6 +130,88 @@ func TestHandlerServesSDPAnswer(t *testing.T) {
 	if got := result.Header.Get("Content-Type"); got != "application/sdp" {
 		t.Fatalf("content type = %q, want application/sdp", got)
 	}
+}
+
+func TestHandlerRejectsOversizedSDPOffer(t *testing.T) {
+	handler := NewHandler()
+	req := httptest.NewRequest(http.MethodPost, "/v1/join/123", strings.NewReader(strings.Repeat("x", int(maxSDPBodySize)+1)))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	if result.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", result.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestServeTLSCloseCancelsContextWithoutServerClosedCause(t *testing.T) {
+	certFile, keyFile := writeTestCertificate(t)
+	handler, err := HandlerConfig{}.ServeTLS("127.0.0.1:0", certFile, keyFile)
+	if err != nil {
+		t.Fatalf("ServeTLS() error = %v", err)
+	}
+
+	if err := handler.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	select {
+	case <-handler.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handler context cancellation")
+	}
+	if err := context.Cause(handler.Context()); errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("context cause = %v, want clean close cause", err)
+	} else if !errors.Is(err, context.Canceled) {
+		t.Fatalf("context cause = %v, want %v", err, context.Canceled)
+	}
+}
+
+func newTestHandler() *Handler {
+	handler := NewHandler()
+	handler.disableNotifyTypeCheck = true
+	return handler
+}
+
+func writeTestCertificate(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, err := x509.CreateCertificate(cryptorand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
+		t.Fatalf("write certificate: %v", err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certFile, keyFile
 }
 
 type notifierFunc func(*nethernet.Signal)

--- a/endpoint/client_test.go
+++ b/endpoint/client_test.go
@@ -105,8 +105,37 @@ func TestHandlerServesSDPAnswer(t *testing.T) {
 	}
 }
 
+func TestHandlerReturnsServiceUnavailableWhenOfferNotAdmitted(t *testing.T) {
+	enableHandlerNotifyCheck = false
+	t.Cleanup(func() {
+		enableHandlerNotifyCheck = true
+	})
+
+	handler := NewHandler()
+	stop := handler.Notify(rejectingNotifier{})
+	defer stop()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/join/123", strings.NewReader("offer"))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	if result.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", result.StatusCode, http.StatusServiceUnavailable)
+	}
+}
+
 type notifierFunc func(*nethernet.Signal)
 
-func (f notifierFunc) NotifySignal(signal *nethernet.Signal) {
+func (f notifierFunc) NotifySignal(signal *nethernet.Signal) bool {
 	f(signal)
+	return true
+}
+
+type rejectingNotifier struct{}
+
+func (rejectingNotifier) NotifySignal(*nethernet.Signal) bool {
+	return false
 }

--- a/endpoint/example_test.go
+++ b/endpoint/example_test.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand/v2"
 	"net/http"
-	"net/url"
-	"strconv"
 
 	"github.com/df-mc/go-nethernet"
 )
@@ -16,14 +13,11 @@ import (
 func ExampleClient() {
 	// Create a signaling client.
 	// This client is responsible for exchanging WebRTC connection details with the server over HTTP.
-	client := NewClient(&url.URL{
-		Scheme: "http",
-		Host:   ":19132",
-	})
+	client := NewClient()
 
 	// Establish a NetherNet connection using the client for the signaling.
 	var d nethernet.Dialer
-	conn, err := d.DialContext(context.TODO(), strconv.FormatUint(rand.Uint64(), 10), client)
+	conn, err := d.DialContext(context.TODO(), "https://localhost:19132", client)
 	if err != nil {
 		panic(fmt.Sprintf("error connecting to server: %s", err))
 	}

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -95,34 +95,24 @@ func (conf HandlerConfig) ServeTLS(address string, certFile, keyFile string) (*H
 	h.ctx, cancel = context.WithCancelCause(context.Background())
 	server := &http.Server{
 		Handler:           h,
-		ReadHeaderTimeout: serveTLSReadHeaderTimeout,
-		ReadTimeout:       serveTLSReadTimeout,
-		IdleTimeout:       serveTLSIdleTimeout,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       30 * time.Second,
 	}
 	// Call [http.Server.Serve] in a goroutine since it is a blocking method.
 	go func() {
-		if err := server.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Serve(l); err != nil {
 			cancel(err)
 		}
 	}()
 	h.closeFunc = func() error {
-		err := server.Close()
-		cancel(nil)
-		return err
+		return server.Close()
 	}
 	return h, nil
 }
 
-const (
-	// maxSDPBodySize caps HTTP SDP offer and answer bodies at 1 MiB.
-	maxSDPBodySize int64 = 1 << 20
-	// serveTLSReadHeaderTimeout bounds how long a client may spend sending request headers.
-	serveTLSReadHeaderTimeout = 5 * time.Second
-	// serveTLSReadTimeout bounds how long a client may spend sending a complete request.
-	serveTLSReadTimeout = 10 * time.Second
-	// serveTLSIdleTimeout bounds how long an idle keep-alive connection may remain open.
-	serveTLSIdleTimeout = 30 * time.Second
-)
+// maxSDPBodySize caps HTTP SDP offer and answer bodies at 1 MiB.
+const maxSDPBodySize int64 = 1 << 20
 
 // ServeTLS is a utility method that set-ups an HTTP/TLS server on the specified
 // address using the TLS certificate and key file. It is equivalent of

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -296,7 +296,6 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 	signal, err := h.negotiate(ctx, networkID, string(b))
 	if err != nil {
 		log.Error("error negotiating",
-			slog.Int("offerSize", len(b)),
 			slog.String("offer", string(b)),
 			slog.Any("error", err),
 		)

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -278,6 +278,10 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 	signal, err := h.negotiate(ctx, networkID, string(b))
 	if err != nil {
 		log.Error("error negotiating", slog.String("offer", string(b)), slog.Any("error", err))
+		if errors.Is(err, errOfferNotAdmitted) {
+			writeText(w, http.StatusServiceUnavailable, "Service unavailable")
+			return
+		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			writeText(w, http.StatusBadGateway, "Timed out waiting for answer")
 			return
@@ -347,11 +351,13 @@ func (h *Handler) negotiate(ctx context.Context, networkID, offer string) (*neth
 		h.pendingMu.Unlock()
 	}()
 
-	notifier.NotifySignal(signal)
+	if !notifier.NotifySignal(signal) {
+		return nil, errOfferNotAdmitted
+	}
 
 	select {
 	case <-ctx.Done():
-		notifier.NotifySignal(&nethernet.Signal{
+		_ = notifier.NotifySignal(&nethernet.Signal{
 			Type:         nethernet.SignalTypeError,
 			ConnectionID: signal.ConnectionID,
 			Data:         strconv.FormatUint(nethernet.ErrorCodeNegotiationTimeoutWaitingForResponse, 10),
@@ -362,6 +368,10 @@ func (h *Handler) negotiate(ctx context.Context, networkID, offer string) (*neth
 		return result, nil
 	}
 }
+
+// errOfferNotAdmitted reports that the listener rejected or dropped an offer
+// before it could be processed.
+var errOfferNotAdmitted = errors.New("nethernet/endpoint: offer not admitted")
 
 // ServeHTTP implements [http.Handler] by delegating the given response writer
 // and the request to the internal [http.ServeMux].

--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -93,18 +93,36 @@ func (conf HandlerConfig) ServeTLS(address string, certFile, keyFile string) (*H
 	h := conf.New()
 	var cancel context.CancelCauseFunc
 	h.ctx, cancel = context.WithCancelCause(context.Background())
-	server := &http.Server{Handler: h}
+	server := &http.Server{
+		Handler:           h,
+		ReadHeaderTimeout: serveTLSReadHeaderTimeout,
+		ReadTimeout:       serveTLSReadTimeout,
+		IdleTimeout:       serveTLSIdleTimeout,
+	}
 	// Call [http.Server.Serve] in a goroutine since it is a blocking method.
 	go func() {
-		if err := server.Serve(l); err != nil {
+		if err := server.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			cancel(err)
 		}
 	}()
 	h.closeFunc = func() error {
-		return server.Close()
+		err := server.Close()
+		cancel(nil)
+		return err
 	}
 	return h, nil
 }
+
+const (
+	// maxSDPBodySize caps HTTP SDP offer and answer bodies at 1 MiB.
+	maxSDPBodySize int64 = 1 << 20
+	// serveTLSReadHeaderTimeout bounds how long a client may spend sending request headers.
+	serveTLSReadHeaderTimeout = 5 * time.Second
+	// serveTLSReadTimeout bounds how long a client may spend sending a complete request.
+	serveTLSReadTimeout = 10 * time.Second
+	// serveTLSIdleTimeout bounds how long an idle keep-alive connection may remain open.
+	serveTLSIdleTimeout = 30 * time.Second
+)
 
 // ServeTLS is a utility method that set-ups an HTTP/TLS server on the specified
 // address using the TLS certificate and key file. It is equivalent of
@@ -143,6 +161,9 @@ type Handler struct {
 	notifier   nethernet.Notifier
 	notifierID uint64
 	notifierMu sync.RWMutex
+
+	// disableNotifyTypeCheck permits tests to register lightweight Notifier stubs.
+	disableNotifyTypeCheck bool
 }
 
 // Signal delivers a signal to the pending negotiation identified by the
@@ -169,17 +190,12 @@ func (h *Handler) Signal(ctx context.Context, signal *nethernet.Signal) error {
 	}
 }
 
-// enableHandlerNotifyCheck determines whether to ensure that the [nethernet.Notifier]
-// passed to [Handler.Notify] is [nethernet.Listener]. It is used for testing.
-var enableHandlerNotifyCheck = true
-
 // Notify registers n to receive incoming HTTP endpoint offers.
 func (h *Handler) Notify(n nethernet.Notifier) (stop func()) {
 	if n == nil {
 		panic("nethernet/endpoint: Handler.Notify: nil Notifier")
 	}
-	//noinspection GoBoolExpressions enableHandlerNotifyCheck can be false in testing environment.
-	if _, ok := n.(*nethernet.Listener); enableHandlerNotifyCheck && !ok {
+	if _, ok := n.(*nethernet.Listener); !h.disableNotifyTypeCheck && !ok {
 		panic(fmt.Sprintf("nethernet/endpoint: Handler can only be used with *nethernet.Listener: %T", n))
 	}
 	h.notifierMu.Lock()
@@ -265,9 +281,21 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 	}
 	log = log.With("networkID", networkID)
 
+	req.Body = http.MaxBytesReader(w, req.Body, maxSDPBodySize)
 	b, err := io.ReadAll(req.Body)
-	if err != nil || len(b) == 0 {
-		log.Error("error reading response body", "error", err, "contentLength", len(b))
+	if err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			log.Error("SDP offer is too large", "limit", maxBytesError.Limit)
+			writeText(w, http.StatusRequestEntityTooLarge, "SDP offer is too large")
+			return
+		}
+		log.Error("error reading request body", "error", err)
+		writeText(w, http.StatusBadRequest, "Missing SDP offer in request body")
+		return
+	}
+	if len(b) == 0 {
+		log.Error("missing SDP offer in request body")
 		writeText(w, http.StatusBadRequest, "Missing SDP offer in request body")
 		return
 	}
@@ -277,7 +305,11 @@ func (h *Handler) handleOffer(w http.ResponseWriter, req *http.Request) {
 
 	signal, err := h.negotiate(ctx, networkID, string(b))
 	if err != nil {
-		log.Error("error negotiating", slog.String("offer", string(b)), slog.Any("error", err))
+		log.Error("error negotiating",
+			slog.Int("offerSize", len(b)),
+			slog.String("offer", string(b)),
+			slog.Any("error", err),
+		)
 		if errors.Is(err, context.DeadlineExceeded) {
 			writeText(w, http.StatusBadGateway, "Timed out waiting for answer")
 			return

--- a/examples/endpoint/client/main.go
+++ b/examples/endpoint/client/main.go
@@ -20,8 +20,8 @@ func init() {
 }
 
 // main is a program that demonstrates a client connecting to the server over NetherNet
-// using HTTP endpoint as the signaling method. The server must be running in offline mode
-// since it does not perform identity assertion.
+// using HTTP endpoint as the signaling method. This example does not configure a
+// client identity, so the server must allow anonymous/offline connections.
 func main() {
 	address := flag.Arg(0)
 	if address == "" {

--- a/examples/endpoint/client/main.go
+++ b/examples/endpoint/client/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"os/signal"
 	"time"
@@ -33,14 +32,10 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
 	defer cancel()
 
-	u, err := url.Parse(address)
-	if err != nil {
-		panic(fmt.Sprintf("error parsing URL: %s", err))
-	}
-	client := endpoint.NewClient(u)
+	client := endpoint.NewClient()
 
-	slog.Info("establishing connection over NetherNet... send an interrupt signal (Ctrl+C) to abort", "url", u)
-	conn, err := nethernet.Dialer{DisableTrickleICE: true}.DialContext(ctx, client.NetworkID(), client)
+	slog.Info("establishing connection over NetherNet... send an interrupt signal (Ctrl+C) to abort", "url", address)
+	conn, err := nethernet.Dialer{DisableTrickleICE: true}.DialContext(ctx, address, client)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/endpoint/server/main.go
+++ b/examples/endpoint/server/main.go
@@ -50,7 +50,12 @@ func main() {
 	}
 
 	server := endpoint.NewHandler()
-	l, err := nethernet.ListenConfig{DisableTrickleICE: true}.Listen(server)
+	l, err := nethernet.ListenConfig{
+		// The example client does not send an identity assertion, so this
+		// endpoint server opts into anonymous/offline connections explicitly.
+		AllowAnonymous:    true,
+		DisableTrickleICE: true,
+	}.Listen(server)
 	if err != nil {
 		panic(fmt.Sprintf("error listening on NetherNet: %s", err))
 	}

--- a/identity.go
+++ b/identity.go
@@ -39,7 +39,7 @@ type Identity struct {
 }
 
 // sign signs the DTLS fingerprints included in the given local description using
-// the [Identity.PublicKey], and returns an identityData that can be embedded
+// the [Identity.PrivateKey], and returns an identityData that can be embedded
 // to the description.
 func (i Identity) sign(desc *description) error {
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: i.PrivateKey}, nil)
@@ -104,13 +104,17 @@ func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 // Identity contains a self-signed JWT token with a 1-minute expiration time and the public key
 // embedded as the 'cpk' claim.
 func GenerateServerIdentity(privateKey *ecdsa.PrivateKey, domain string) (*Identity, error) {
+	encodedPublicKey, err := encodePublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("encode public key: %w", err)
+	}
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, &jose.SignerOptions{
 		ExtraHeaders: map[jose.HeaderKey]any{
 			// On Bedrock Dedicated Servers, just like the JWT token included in the
 			// ServerToClientHandshake packet, this JWT token also includes the public
 			// key in the 'x5u' claim.
 			// Though it is not strictly required, we do this to match vanilla behavior.
-			"x5u": encodePublicKey(&privateKey.PublicKey),
+			"x5u": encodedPublicKey,
 		},
 	})
 	if err != nil {
@@ -144,10 +148,14 @@ type tokenClaims struct {
 // It performs additional handling for encoding the cpk claim in base64.
 func (c tokenClaims) MarshalJSON() ([]byte, error) {
 	type Alias tokenClaims
+	publicKey, err := encodePublicKey(c.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("encode cpk: %w", err)
+	}
 	return json.Marshal(struct {
 		Alias
 		PublicKey string `json:"cpk"`
-	}{Alias: (Alias)(c), PublicKey: encodePublicKey(c.PublicKey)})
+	}{Alias: (Alias)(c), PublicKey: publicKey})
 }
 
 // UnmarshalJSON implements [json.Unmarshaler] for tokenClaims.
@@ -275,12 +283,15 @@ func (a *identityAssertion) UnmarshalJSON(b []byte) error {
 }
 
 // encodePublicKey encodes an ECDSA public key given by the user to a base64-encoded string.
-func encodePublicKey(publicKey *ecdsa.PublicKey) string {
+func encodePublicKey(publicKey *ecdsa.PublicKey) (string, error) {
+	if publicKey == nil {
+		return "", errors.New("nethernet: public key is nil")
+	}
 	b, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
-		panic(fmt.Sprintf("error encoding public key: %s", err))
+		return "", fmt.Errorf("marshal PKIX public key: %w", err)
 	}
-	return base64.StdEncoding.EncodeToString(b)
+	return base64.StdEncoding.EncodeToString(b), nil
 }
 
 // parsePublicKey decodes a base64-encoded string as an ECDSA public key.

--- a/identity_test.go
+++ b/identity_test.go
@@ -1,0 +1,109 @@
+package nethernet
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/pion/webrtc/v4"
+)
+
+func TestIdentitySignVerifyRoundTrip(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	identity, err := GenerateServerIdentity(privateKey, "self")
+	if err != nil {
+		t.Fatalf("GenerateServerIdentity() error = %v", err)
+	}
+	publicKey, err := claimPublicKey(identity.Token, true)
+	if err != nil {
+		t.Fatalf("claimPublicKey() error = %v", err)
+	}
+
+	desc := newIdentityTestDescription()
+	if err := identity.sign(desc); err != nil {
+		t.Fatalf("sign() error = %v", err)
+	}
+	if err := desc.identity.verify(desc, publicKey); err != nil {
+		t.Fatalf("verify() error = %v", err)
+	}
+}
+
+func TestIdentityVerifyRejectsTamperedFingerprint(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	identity, err := GenerateServerIdentity(privateKey, "self")
+	if err != nil {
+		t.Fatalf("GenerateServerIdentity() error = %v", err)
+	}
+	publicKey, err := claimPublicKey(identity.Token, true)
+	if err != nil {
+		t.Fatalf("claimPublicKey() error = %v", err)
+	}
+
+	desc := newIdentityTestDescription()
+	if err := identity.sign(desc); err != nil {
+		t.Fatalf("sign() error = %v", err)
+	}
+	desc.dtls.Fingerprints[0].Value = "FF:FF:FF:FF"
+	if err := desc.identity.verify(desc, publicKey); err == nil {
+		t.Fatal("verify() succeeded for tampered fingerprint")
+	}
+}
+
+func TestClaimPublicKeyRejectsExpiredToken(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	token, err := newIdentityTestToken(privateKey, time.Now().Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestToken() error = %v", err)
+	}
+	if _, err := claimPublicKey(token, true); err == nil {
+		t.Fatal("claimPublicKey() succeeded for expired token")
+	}
+}
+
+func TestTokenClaimsMarshalRejectsNilPublicKey(t *testing.T) {
+	_, err := json.Marshal(tokenClaims{})
+	if err == nil || !strings.Contains(err.Error(), "public key is nil") {
+		t.Fatalf("MarshalJSON() error = %v, want nil public key error", err)
+	}
+}
+
+func newIdentityTestDescription() *description {
+	return &description{
+		dtls: webrtc.DTLSParameters{
+			Fingerprints: []webrtc.DTLSFingerprint{{
+				Algorithm: "sha-256",
+				Value:     "00:11:22:33:44:55:66:77",
+			}},
+		},
+	}
+}
+
+func newIdentityTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), cryptorand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	return privateKey
+}
+
+func newIdentityTestToken(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (string, error) {
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, nil)
+	if err != nil {
+		return "", err
+	}
+	issuedAt := expiresAt.Add(-time.Minute)
+	return jwt.Signed(signer).Claims(tokenClaims{
+		Claims: jwt.Claims{
+			Expiry:   jwt.NewNumericDate(expiresAt),
+			IssuedAt: jwt.NewNumericDate(issuedAt),
+		},
+		PublicKey: &privateKey.PublicKey,
+	}).Serialize()
+}

--- a/listener.go
+++ b/listener.go
@@ -75,18 +75,21 @@ type ListenConfig struct {
 	// verification using the public keys exposed by Minecraft's authorization service,
 	// as this library does not provide access to that endpoint.
 	//
-	// This is still safe because the Minecraft protocol layer verifies the same
-	// token present in the Login packet's connection request and checks that the
-	// same public key was used in the 'cpk' claim. Even if an attacker replayed
-	// a token, they could not replace the 'cpk' claim without invalidating the JWT
-	// signature, and therefore would be unable to produce a valid signature for the DTLS
-	// fingerprint assertion.
+	// The default verifier only binds the SDP identity assertion to the public
+	// key in the token. It is appropriate for Bedrock integrations only when the
+	// Minecraft protocol layer also verifies the Login packet token and checks
+	// that the same public key was used in its 'cpk' claim. Servers that rely on
+	// NetherNet identity alone should provide a verifier that validates token
+	// issuance.
 	VerifyClientToken func(ctx context.Context, token string) (*ecdsa.PublicKey, error)
 
 	// AllowAnonymous determines whether SDP offers without an 'a=identity'
 	// attribute are accepted.
 	// When set to false, all incoming connections must provide a valid identity
 	// assertion. When set to true, unauthenticated peers are allowed to connect.
+	//
+	// The zero value is false. Set this explicitly for offline/custom clients
+	// that do not send identity assertions.
 	//
 	// This may be useful for implementing offline-mode servers, but it removes
 	// the identity binding normally provided by NetherNet and may allow replay

--- a/listener.go
+++ b/listener.go
@@ -273,14 +273,19 @@ func (l *Listener) PongData(b []byte) {
 	l.signaling.PongData(b)
 }
 
-// NotifySignal handles an incoming Signal from the remote network.
-func (l *Listener) NotifySignal(signal *Signal) {
+// NotifySignal handles an incoming Signal from the remote network and reports
+// whether it was accepted for processing.
+func (l *Listener) NotifySignal(signal *Signal) bool {
 	select {
 	case l.signals <- signal:
+		return true
 	case <-l.Context().Done():
+		return false
 	case <-l.signaling.Context().Done():
+		return false
 	default:
 		l.log().Warn("dropping signal because channel buffer is full", slog.Any("signal", signal))
+		return false
 	}
 }
 

--- a/listener.go
+++ b/listener.go
@@ -397,21 +397,25 @@ func (l *Listener) handleOffer(signal *Signal) error {
 	if desc.identity != nil {
 		publicKey, err := l.conf.VerifyClientToken(ctx, desc.identity.Assertion.Token)
 		if err != nil {
-			return wrapSignalError(fmt.Errorf("verify client token: %w", err), 37)
+			return wrapSignalError(fmt.Errorf("verify client token: %w", err), ErrorCodeIdentityVerificationFailed)
 		}
 		if err := desc.identity.verify(desc, publicKey); err != nil {
-			return wrapSignalError(fmt.Errorf("verify identity assertion: %w", err), 37)
+			return wrapSignalError(fmt.Errorf("verify identity assertion: %w", err), ErrorCodeIdentityVerificationFailed)
 		}
 		c.publicKey = publicKey
 	} else if !l.conf.AllowAnonymous {
-		return wrapSignalError(errors.New("nethernet: anonymous identity not allowed"), 37)
+		l.conf.Log.Warn("rejecting anonymous identity because AllowAnonymous is false",
+			slog.Uint64("connectionID", signal.ConnectionID),
+			slog.String("networkID", signal.NetworkID),
+		)
+		return wrapSignalError(errors.New("nethernet: anonymous identity not allowed"), ErrorCodeIdentityVerificationFailed)
 	}
 	identity, err := l.conf.IssueServerIdentity(ctx)
 	if err != nil {
-		return wrapSignalError(fmt.Errorf("issue server identity: %w", err), 37)
+		return wrapSignalError(fmt.Errorf("issue server identity: %w", err), ErrorCodeIdentityVerificationFailed)
 	}
 	if err := identity.sign(c.description); err != nil {
-		return wrapSignalError(fmt.Errorf("generate identity assertion: %w", err), 37)
+		return wrapSignalError(fmt.Errorf("generate identity assertion: %w", err), ErrorCodeIdentityVerificationFailed)
 	}
 
 	// Register a callback function immediately since the remote peer

--- a/signal.go
+++ b/signal.go
@@ -46,8 +46,9 @@ type Signaling interface {
 // Notifier receives incoming Signals from a Signaling implementation.
 type Notifier interface {
 	// NotifySignal handles an incoming Signal from a remote network. It must
-	// return promptly and must not block the Signaling implementation.
-	NotifySignal(signal *Signal)
+	// return promptly and must not block the Signaling implementation. It
+	// reports whether the Signal was accepted for processing.
+	NotifySignal(signal *Signal) bool
 }
 
 // trickleICEDisabler is implemented by Signaling when they're not capable

--- a/signal.go
+++ b/signal.go
@@ -222,4 +222,8 @@ const (
 	ErrorCodeNoSignalingChannel
 	ErrorCodeNotLoggedIn
 	ErrorCodeSignalingFailedToSend
+
+	// ErrorCodeIdentityVerificationFailed reports that the remote identity token
+	// or its DTLS fingerprint assertion failed validation.
+	ErrorCodeIdentityVerificationFailed = 37
 )


### PR DESCRIPTION
## Summary

- make Notifier.NotifySignal report whether a signal was accepted for processing
- have Listener return false when it is closed, signaling is closed, or the signal queue is full
- return HTTP 503 from endpoint offers that are not admitted instead of waiting for the negotiation timeout
- add a regression test for the rejected-offer path

## Notes

This intentionally changes the Notifier interface from fire-and-forget to admission-aware. Broadcast-style callers ignore the return value, while request/response paths such as endpoint.Handler can map a rejected offer to capacity failure immediately.

## Validation

- go test ./...
- go vet ./...
- git diff --check
