### PR TITLE
discovery: update ServerData to version 5

### DIFF
--- a/discovery/binary.go
+++ b/discovery/binary.go
@@ -1,0 +1,98 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+func writeInt32(buf *bytes.Buffer, v int32) {
+	var b [4]byte
+	binary.LittleEndian.PutUint32(b[:], uint32(v))
+	buf.Write(b[:])
+}
+
+func readInt32(r io.Reader) (int32, error) {
+	var b [4]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return 0, err
+	}
+	return int32(binary.LittleEndian.Uint32(b[:])), nil
+}
+
+func writeBool(buf *bytes.Buffer, v bool) {
+	if v {
+		buf.WriteByte(1)
+		return
+	}
+	buf.WriteByte(0)
+}
+
+func readBool(r io.ByteReader) (bool, error) {
+	b, err := r.ReadByte()
+	return b != 0, err
+}
+
+func writeString(buf *bytes.Buffer, s string) {
+	writeVaruint32(buf, uint32(len(s)))
+	buf.WriteString(s)
+}
+
+func readString(buf *bytes.Buffer) (string, error) {
+	length, err := readVaruint32(buf)
+	if err != nil {
+		return "", err
+	}
+	if int(length) > buf.Len() {
+		return "", fmt.Errorf("string length %d exceeds remaining %d bytes", length, buf.Len())
+	}
+	b := make([]byte, length)
+	if _, err := io.ReadFull(buf, b); err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func writeVarint32(buf *bytes.Buffer, v int32) {
+	u := uint32(v) << 1
+	if v < 0 {
+		u = ^u
+	}
+	writeVaruint32(buf, u)
+}
+
+func readVarint32(r io.ByteReader) (int32, error) {
+	u, err := readVaruint32(r)
+	if err != nil {
+		return 0, err
+	}
+	v := int32(u >> 1)
+	if u&1 != 0 {
+		v = ^v
+	}
+	return v, nil
+}
+
+func writeVaruint32(buf *bytes.Buffer, v uint32) {
+	for v >= 0x80 {
+		buf.WriteByte(byte(v) | 0x80)
+		v >>= 7
+	}
+	buf.WriteByte(byte(v))
+}
+
+func readVaruint32(r io.ByteReader) (uint32, error) {
+	var v uint32
+	for i := uint(0); i < 35; i += 7 {
+		b, err := r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		v |= uint32(b&0x7f) << i
+		if b&0x80 == 0 {
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("varuint32 did not terminate after 5 bytes")
+}

--- a/discovery/example_listener_test.go
+++ b/discovery/example_listener_test.go
@@ -22,13 +22,15 @@ func ExampleListen() {
 	}
 	defer d.Close()
 	d.ServerData(&ServerData{
-		ServerName:     "df-mc/go-nethernet",
-		LevelName:      "Bedrock World",
-		GameType:       2,
-		PlayerCount:    1,
-		MaxPlayerCount: 8,
-		TransportLayer: 2,
-		ConnectionType: 4,
+		ServerName:            "df-mc/go-nethernet",
+		LevelName:             "Bedrock World",
+		GameType:              GameTypeAdventure,
+		PlayerCount:           1,
+		MaxPlayerCount:        8,
+		AcceptsOnlineAuth:     true,
+		AcceptsSelfSignedAuth: true,
+		TransportLayer:        TransportLayerNetherNet,
+		ConnectionType:        4,
 	})
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/discovery/listener.go
+++ b/discovery/listener.go
@@ -359,29 +359,31 @@ func (l *Listener) PongData(b []byte) {
 	}
 
 	d := &ServerData{
-		ServerName:     parts[1],
-		LevelName:      parts[7],
-		GameType:       gameType,
-		PlayerCount:    int32(players),
-		MaxPlayerCount: int32(maxPlayers),
-		EditorWorld:    false,
-		Hardcore:       false,
-		TransportLayer: 2,
-		ConnectionType: 4,
+		ServerName:            parts[1],
+		LevelName:             parts[7],
+		GameType:              gameType,
+		PlayerCount:           int32(players),
+		MaxPlayerCount:        int32(maxPlayers),
+		EditorWorld:           false,
+		Hardcore:              false,
+		AcceptsOnlineAuth:     true,
+		AcceptsSelfSignedAuth: true,
+		TransportLayer:        TransportLayerNetherNet,
+		ConnectionType:        4,
 	}
 	l.ServerData(d)
 }
 
-// parsePongGameType converts the game type string from the pong data to its uint8 representation.
+// parsePongGameType converts the game type string from the pong data to its int32 representation.
 // Returns 0 and false if the game type is not valid.
-func parsePongGameType(v string) (uint8, bool) {
+func parsePongGameType(v string) (int32, bool) {
 	switch strings.ToLower(strings.TrimSpace(v)) {
 	case "survival":
-		return 0, true
+		return GameTypeSurvival, true
 	case "creative":
-		return 1, true
+		return GameTypeCreative, true
 	case "adventure":
-		return 2, true
+		return GameTypeAdventure, true
 	}
 	return 0, false
 }

--- a/discovery/server_data.go
+++ b/discovery/server_data.go
@@ -2,8 +2,24 @@ package discovery
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
+)
+
+// GameType represents the default game mode of a world.
+const (
+	GameTypeSurvival       int32 = 0
+	GameTypeCreative       int32 = 1
+	GameTypeAdventure      int32 = 2
+	GameTypeSurvivalViewer int32 = 3
+	GameTypeCreativeViewer int32 = 4
+	GameTypeDefault        int32 = 5
+)
+
+// TransportLayer indicates the transport protocol used by a server.
+const (
+	TransportLayerRakNet    int32 = 0
+	TransportLayerNetherNet int32 = 2
+	TransportLayerLocal     int32 = 4
 )
 
 // ServerData defines the binary structure representing worlds in Minecraft: Bedrock Edition.
@@ -17,7 +33,7 @@ type ServerData struct {
 	LevelName string
 	// GameType is the default game mode of the world. Players receive this game mode when they
 	// join. It remains unchanged during gameplay and may be updated the next time the world is hosted.
-	GameType uint8
+	GameType int32
 	// PlayerCount is the amount of players currently connected to the world. Worlds
 	// with a player count of 0 or less are not displayed by clients, so it should at
 	// least 1 even if the server reports 0 to prevent world cards not appearing for the server.
@@ -30,39 +46,36 @@ type ServerData struct {
 	// Hardcore indicates that the world is in hardcore mode. When enabled, it is common to also set
 	// GameType to Survival (0) as well to reproduce expected behavior.
 	Hardcore bool
+	// AcceptsOnlineAuth indicates whether the server accepts online-authenticated (Xbox Live) players.
+	AcceptsOnlineAuth bool
+	// AcceptsSelfSignedAuth indicates whether the server accepts self-signed (LAN) authentication.
+	AcceptsSelfSignedAuth bool
 	// TransportLayer indicates the transport layer used by the server. In vanilla, this is typically
 	// 2 for NetherNet. Other values are also supported but are currently not useful in LAN discovery
 	// as it only allows connections over NetherNet. Therefore, the purposes or usage of this field is
 	// currently unknown.
-	TransportLayer uint8
+	TransportLayer int32
 	// ConnectionType indicates the connection type used alongside the transport layer.
 	// In vanilla, this is typically 4 for using LAN as a signaling for NetherNet.
 	// Other values are supported but are currently not useful in LAN discovery.
-	ConnectionType uint8
+	ConnectionType int32
 }
 
 // MarshalBinary ...
 func (d *ServerData) MarshalBinary() ([]byte, error) {
 	buf := &bytes.Buffer{}
-	serverName := []byte(d.ServerName)
-	if len(serverName) > maxServerDataNameLength {
-		return nil, fmt.Errorf("server name length %d exceeds %d byte limit", len(serverName), maxServerDataNameLength)
-	}
-	levelName := []byte(d.LevelName)
-	if len(levelName) > maxServerDataNameLength {
-		return nil, fmt.Errorf("level name length %d exceeds %d byte limit", len(levelName), maxServerDataNameLength)
-	}
-
-	_ = binary.Write(buf, binary.LittleEndian, version)
-	writeBytes[uint8](buf, serverName)
-	writeBytes[uint8](buf, levelName)
-	_ = binary.Write(buf, binary.LittleEndian, d.GameType<<1)
-	_ = binary.Write(buf, binary.LittleEndian, d.PlayerCount)
-	_ = binary.Write(buf, binary.LittleEndian, d.MaxPlayerCount)
-	_ = binary.Write(buf, binary.LittleEndian, d.EditorWorld)
-	_ = binary.Write(buf, binary.LittleEndian, d.Hardcore)
-	_ = binary.Write(buf, binary.LittleEndian, d.TransportLayer<<1)
-	_ = binary.Write(buf, binary.LittleEndian, d.ConnectionType<<1)
+	buf.WriteByte(version)
+	writeString(buf, d.ServerName)
+	writeString(buf, d.LevelName)
+	writeVarint32(buf, d.GameType)
+	writeInt32(buf, d.PlayerCount)
+	writeInt32(buf, d.MaxPlayerCount)
+	writeBool(buf, d.EditorWorld)
+	writeBool(buf, d.Hardcore)
+	writeBool(buf, d.AcceptsOnlineAuth)
+	writeBool(buf, d.AcceptsSelfSignedAuth)
+	writeVarint32(buf, d.TransportLayer)
+	writeVarint32(buf, d.ConnectionType)
 
 	return buf.Bytes(), nil
 }
@@ -71,50 +84,57 @@ func (d *ServerData) MarshalBinary() ([]byte, error) {
 func (d *ServerData) UnmarshalBinary(data []byte) error {
 	buf := bytes.NewBuffer(data)
 
-	var v uint8
-	if err := binary.Read(buf, binary.LittleEndian, &v); err != nil {
-		return fmt.Errorf("read version: %s", err)
+	v, err := buf.ReadByte()
+	if err != nil {
+		return fmt.Errorf("read version: %w", err)
 	}
 	if v != version {
 		return fmt.Errorf("version mismatch: got %d, want %d", v, version)
 	}
-	serverName, err := readBytes[uint8](buf)
+	d.ServerName, err = readString(buf)
 	if err != nil {
 		return fmt.Errorf("read server name: %w", err)
 	}
-	d.ServerName = string(serverName)
-	levelName, err := readBytes[uint8](buf)
+	d.LevelName, err = readString(buf)
 	if err != nil {
 		return fmt.Errorf("read level name: %w", err)
 	}
-	d.LevelName = string(levelName)
-	var gameType uint8
-	if err := binary.Read(buf, binary.LittleEndian, &gameType); err != nil {
+	d.GameType, err = readVarint32(buf)
+	if err != nil {
 		return fmt.Errorf("read game type: %w", err)
 	}
-	d.GameType = gameType >> 1
-	if err := binary.Read(buf, binary.LittleEndian, &d.PlayerCount); err != nil {
+	d.PlayerCount, err = readInt32(buf)
+	if err != nil {
 		return fmt.Errorf("read player count: %w", err)
 	}
-	if err := binary.Read(buf, binary.LittleEndian, &d.MaxPlayerCount); err != nil {
+	d.MaxPlayerCount, err = readInt32(buf)
+	if err != nil {
 		return fmt.Errorf("read max player count: %w", err)
 	}
-	if err := binary.Read(buf, binary.LittleEndian, &d.EditorWorld); err != nil {
+	d.EditorWorld, err = readBool(buf)
+	if err != nil {
 		return fmt.Errorf("read editor world: %w", err)
 	}
-	if err := binary.Read(buf, binary.LittleEndian, &d.Hardcore); err != nil {
+	d.Hardcore, err = readBool(buf)
+	if err != nil {
 		return fmt.Errorf("read hardcore: %w", err)
 	}
-	var transportLayer uint8
-	if err := binary.Read(buf, binary.LittleEndian, &transportLayer); err != nil {
+	d.AcceptsOnlineAuth, err = readBool(buf)
+	if err != nil {
+		return fmt.Errorf("read accepts online auth: %w", err)
+	}
+	d.AcceptsSelfSignedAuth, err = readBool(buf)
+	if err != nil {
+		return fmt.Errorf("read accepts self-signed auth: %w", err)
+	}
+	d.TransportLayer, err = readVarint32(buf)
+	if err != nil {
 		return fmt.Errorf("read transport layer: %w", err)
 	}
-	d.TransportLayer = transportLayer >> 1
-	var connectionType uint8
-	if err := binary.Read(buf, binary.LittleEndian, &connectionType); err != nil {
-		return fmt.Errorf("read unknown: %w", err)
+	d.ConnectionType, err = readVarint32(buf)
+	if err != nil {
+		return fmt.Errorf("read connection type: %w", err)
 	}
-	d.ConnectionType = connectionType >> 1
 	if length := buf.Len(); length != 0 {
 		return fmt.Errorf("unread %d bytes", length)
 	}
@@ -123,7 +143,4 @@ func (d *ServerData) UnmarshalBinary(data []byte) error {
 }
 
 // version is the current version of ServerData as supported by the `discovery` package.
-const version uint8 = 4
-
-// maxServerDataNameLength is 255 bytes, matching the uint8 string length prefix.
-const maxServerDataNameLength = 1<<8 - 1
+const version uint8 = 5

--- a/discovery/server_data_test.go
+++ b/discovery/server_data_test.go
@@ -1,42 +1,87 @@
 package discovery
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
 
-func TestServerDataMarshalBinaryRejectsOverlongNames(t *testing.T) {
-	tests := []struct {
-		name string
-		data *ServerData
-	}{
-		{
-			name: "server name",
-			data: testServerData(strings.Repeat("s", maxServerDataNameLength+1), "world"),
-		},
-		{
-			name: "level name",
-			data: testServerData("server", strings.Repeat("l", maxServerDataNameLength+1)),
-		},
-	}
+func TestServerDataMarshalBinaryV5(t *testing.T) {
+	data := testServerData("server", "world")
+	data.Hardcore = true
+	data.AcceptsOnlineAuth = true
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, err := tt.data.MarshalBinary(); err == nil {
-				t.Fatal("MarshalBinary() error = nil, want overlong name error")
-			}
-		})
+	got, err := data.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary() error = %v", err)
+	}
+	want := []byte{
+		0x05,
+		0x06, 's', 'e', 'r', 'v', 'e', 'r',
+		0x05, 'w', 'o', 'r', 'l', 'd',
+		0x04,
+		0x01, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x00, 0x00,
+		0x00,
+		0x01,
+		0x01,
+		0x01,
+		0x04,
+		0x08,
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("MarshalBinary() = % x, want % x", got, want)
+	}
+}
+
+func TestServerDataUnmarshalBinaryV5(t *testing.T) {
+	var data ServerData
+	if err := data.UnmarshalBinary([]byte{
+		0x05,
+		0x06, 's', 'e', 'r', 'v', 'e', 'r',
+		0x05, 'w', 'o', 'r', 'l', 'd',
+		0x04,
+		0x01, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x00, 0x00,
+		0x00,
+		0x01,
+		0x01,
+		0x00,
+		0x04,
+		0x08,
+	}); err != nil {
+		t.Fatalf("UnmarshalBinary() error = %v", err)
+	}
+	if data.ServerName != "server" || data.LevelName != "world" || data.GameType != GameTypeAdventure {
+		t.Fatalf("UnmarshalBinary() = %#v", data)
+	}
+	if data.PlayerCount != 1 || data.MaxPlayerCount != 8 {
+		t.Fatalf("UnmarshalBinary() player counts = %d/%d, want 1/8", data.PlayerCount, data.MaxPlayerCount)
+	}
+	if data.EditorWorld || !data.Hardcore || !data.AcceptsOnlineAuth || data.AcceptsSelfSignedAuth {
+		t.Fatalf("UnmarshalBinary() bools = editor %v hardcore %v online %v self-signed %v", data.EditorWorld, data.Hardcore, data.AcceptsOnlineAuth, data.AcceptsSelfSignedAuth)
+	}
+	if data.TransportLayer != TransportLayerNetherNet || data.ConnectionType != 4 {
+		t.Fatalf("UnmarshalBinary() transport/connection = %d/%d, want 2/4", data.TransportLayer, data.ConnectionType)
+	}
+}
+
+func TestServerDataMarshalBinaryAllowsLongVarintStrings(t *testing.T) {
+	data := testServerData(strings.Repeat("s", 300), strings.Repeat("l", 300))
+	if _, err := data.MarshalBinary(); err != nil {
+		t.Fatalf("MarshalBinary() error = %v", err)
 	}
 }
 
 func testServerData(serverName, levelName string) *ServerData {
 	return &ServerData{
-		ServerName:     serverName,
-		LevelName:      levelName,
-		GameType:       2,
-		PlayerCount:    1,
-		MaxPlayerCount: 8,
-		TransportLayer: 2,
-		ConnectionType: 4,
+		ServerName:            serverName,
+		LevelName:             levelName,
+		GameType:              GameTypeAdventure,
+		PlayerCount:           1,
+		MaxPlayerCount:        8,
+		AcceptsSelfSignedAuth: true,
+		TransportLayer:        TransportLayerNetherNet,
+		ConnectionType:        4,
 	}
 }


### PR DESCRIPTION
## Summary
- Update discovery ServerData to version 5.
- Add the new online-auth and self-signed-auth capability fields.
- Switch ServerData strings and enum-like fields to Bedrock-style varint encodings.
- Move discovery binary primitives into focused helpers and cover the v5 byte layout with fixtures.

## Validation
- go test -count=1 ./...
- git diff --check
