### PR TITLE
discovery: match vanilla length-prefix semantics and stop validating it

### DIFF
--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -64,12 +64,8 @@ func Unmarshal(b []byte) (Packet, uint64, error) {
 	}
 	buf := bytes.NewBuffer(payload)
 
-	var length uint16
-	if err := binary.Read(buf, binary.LittleEndian, &length); err != nil {
-		return nil, 0, fmt.Errorf("read length: %w", err)
-	}
-	// Implementations disagree on the count; decryption and unread-byte checks cover size.
-	_ = length
+	// Skip the unused uint16 length prefix.
+	buf.Next(2)
 	h := &Header{}
 	if err := h.Read(buf); err != nil {
 		return nil, 0, fmt.Errorf("read header: %w", err)

--- a/discovery/packet.go
+++ b/discovery/packet.go
@@ -33,8 +33,9 @@ func Marshal(pk Packet, senderID uint64) []byte {
 
 	pk.Write(buf)
 
+	// Vanilla counts the whole decrypted payload, including this prefix.
 	payload := append(
-		binary.LittleEndian.AppendUint16(nil, uint16(buf.Len())),
+		binary.LittleEndian.AppendUint16(nil, uint16(buf.Len())+2),
 		buf.Bytes()...,
 	)
 	b := encrypt(payload)
@@ -67,9 +68,8 @@ func Unmarshal(b []byte) (Packet, uint64, error) {
 	if err := binary.Read(buf, binary.LittleEndian, &length); err != nil {
 		return nil, 0, fmt.Errorf("read length: %w", err)
 	}
-	if remaining := buf.Len(); int(length) != remaining {
-		return nil, 0, fmt.Errorf("invalid packet length: %d, remaining %d", length, remaining)
-	}
+	// Implementations disagree on the count; decryption and unread-byte checks cover size.
+	_ = length
 	h := &Header{}
 	if err := h.Read(buf); err != nil {
 		return nil, 0, fmt.Errorf("read header: %w", err)

--- a/discovery/packet_test.go
+++ b/discovery/packet_test.go
@@ -9,19 +9,6 @@ import (
 	"testing"
 )
 
-func TestUnmarshalRejectsInvalidPacketLength(t *testing.T) {
-	body := &bytes.Buffer{}
-	(&Header{PacketID: IDRequestPacket, SenderID: 1}).Write(body)
-
-	_, _, err := Unmarshal(sealPayload(append(
-		binary.LittleEndian.AppendUint16(nil, uint16(body.Len()+1)),
-		body.Bytes()...,
-	)))
-	if err == nil || !strings.Contains(err.Error(), "invalid packet length") {
-		t.Fatalf("Unmarshal() error = %v, want invalid packet length", err)
-	}
-}
-
 func TestUnmarshalRejectsOversizedNestedLengths(t *testing.T) {
 	const oversizedLength = uint32(maxPacketPayloadLength)
 
@@ -57,6 +44,61 @@ func TestUnmarshalRejectsOversizedNestedLengths(t *testing.T) {
 	}
 }
 
+func TestUnmarshalAcceptsVanillaInclusiveLength(t *testing.T) {
+	const senderID = 0x1020304050607080
+
+	pk, gotSenderID, err := Unmarshal(requestPacket(senderID, 20))
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if _, ok := pk.(*RequestPacket); !ok {
+		t.Fatalf("Unmarshal() packet = %T, want *RequestPacket", pk)
+	}
+	if gotSenderID != senderID {
+		t.Fatalf("Unmarshal() sender ID = %#x, want %#x", gotSenderID, senderID)
+	}
+}
+
+func TestUnmarshalAcceptsLegacyExclusiveLength(t *testing.T) {
+	const senderID = 0x1020304050607080
+
+	pk, gotSenderID, err := Unmarshal(requestPacket(senderID, 18))
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if _, ok := pk.(*RequestPacket); !ok {
+		t.Fatalf("Unmarshal() packet = %T, want *RequestPacket", pk)
+	}
+	if gotSenderID != senderID {
+		t.Fatalf("Unmarshal() sender ID = %#x, want %#x", gotSenderID, senderID)
+	}
+}
+
+func TestMarshalWritesInclusiveLengthAndRoundTrips(t *testing.T) {
+	const senderID = 0x1020304050607080
+
+	b := Marshal(&RequestPacket{}, senderID)
+	payload, err := decrypt(b[32:])
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	length := binary.LittleEndian.Uint16(payload[:2])
+	if int(length) != len(payload) {
+		t.Fatalf("Marshal() length = %d, want %d", length, len(payload))
+	}
+
+	pk, gotSenderID, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if _, ok := pk.(*RequestPacket); !ok {
+		t.Fatalf("Unmarshal() packet = %T, want *RequestPacket", pk)
+	}
+	if gotSenderID != senderID {
+		t.Fatalf("Unmarshal() sender ID = %#x, want %#x", gotSenderID, senderID)
+	}
+}
+
 func rawPacket(packetID uint16, write func(*bytes.Buffer)) []byte {
 	body := &bytes.Buffer{}
 	(&Header{PacketID: packetID, SenderID: 1}).Write(body)
@@ -67,6 +109,16 @@ func rawPacket(packetID uint16, write func(*bytes.Buffer)) []byte {
 	))
 }
 
+// requestPacket builds an empty discovery request with a chosen length field.
+func requestPacket(senderID uint64, length uint16) []byte {
+	payload := make([]byte, 20)
+	binary.LittleEndian.PutUint16(payload, length)
+	binary.LittleEndian.PutUint16(payload[2:], IDRequestPacket)
+	binary.LittleEndian.PutUint64(payload[4:], senderID)
+	return sealPayload(payload)
+}
+
+// sealPayload encrypts and authenticates a decrypted discovery payload.
 func sealPayload(payload []byte) []byte {
 	hash := hmac.New(sha256.New, key[:])
 	hash.Write(payload)


### PR DESCRIPTION
## Summary

This fixes discovery packet length-prefix handling to match vanilla Minecraft. Vanilla writes the uint16 length field as the whole decrypted payload length, including the two-byte prefix itself, so an empty discovery request has a decrypted payload length of 20 and a length field value of 20.

## Evidence

A live vanilla Minecraft client capture on UDP 7551 sends `length=20` for a 20-byte decrypted discovery request payload. The HMAC validates, so the packet is authentic and the length field is not using go-nethernet's previous exclusive-length interpretation (`18`).

## Impact

Since upstream PR #23 added strict validation of the length prefix against the remaining unread payload, every vanilla discovery request is rejected as a mismatch. go-nethernet servers therefore never respond to vanilla LAN discovery requests, making them invisible in LAN discovery. This also produces repeated error-log spam about every 2 seconds per vanilla client.

## Corroboration

PrismarineJS/node-nethernet reads and ignores this field, and pre-#23 go-nethernet also read and ignored it. The effective payload size is already established by AES/PKCS7 decryption, HMAC validation, and the trailing unread-bytes check after packet decoding.

## Compatibility

`Marshal` now writes the vanilla-inclusive length value, making empty request output byte-identical to vanilla for the decrypted payload length field. `Unmarshal` accepts both vanilla inclusive-length packets and legacy exclusive-length peers by reading and discarding the field.
