### PR TITLE
discovery: remove outdated zero-player LAN comment

### DIFF
--- a/discovery/server_data.go
+++ b/discovery/server_data.go
@@ -18,9 +18,7 @@ type ServerData struct {
 	// GameType is the default game mode of the world. Players receive this game mode when they
 	// join. It remains unchanged during gameplay and may be updated the next time the world is hosted.
 	GameType uint8
-	// PlayerCount is the amount of players currently connected to the world. Worlds
-	// with a player count of 0 or less are not displayed by clients, so it should at
-	// least 1 even if the server reports 0 to prevent world cards not appearing for the server.
+	// PlayerCount is the amount of players currently connected to the world.
 	PlayerCount int32
 	// MaxPlayerCount is the maximum amount of players allowed to join the world.
 	MaxPlayerCount int32


### PR DESCRIPTION
The LAN discovery documentation incorrectly says clients hide worlds with zero players and advises reporting at least one player. That behavior applied to friend worlds, not dedicated servers, so remove the misleading guidance.

Tests: go test ./...