### PR TITLE
identity.go: Accept JSON Web Key encoded cpk claims

### DIFF
--- a/identity.go
+++ b/identity.go
@@ -159,21 +159,52 @@ func (c tokenClaims) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements [json.Unmarshaler] for tokenClaims.
-// It performs additional handling for decoding the cpk claim in base64.
+// It performs additional handling for decoding the cpk claim, which may be
+// encoded either in base64 or as a JSON Web Key.
 func (c *tokenClaims) UnmarshalJSON(b []byte) (err error) {
 	type Alias tokenClaims
 	data := struct {
 		*Alias
-		PublicKey string `json:"cpk"`
+		PublicKey json.RawMessage `json:"cpk"`
 	}{Alias: (*Alias)(c)}
 	if err = json.Unmarshal(b, &data); err != nil {
 		return err
 	}
-	c.PublicKey, err = parsePublicKey(data.PublicKey)
+	c.PublicKey, err = parseClaimPublicKey(data.PublicKey)
 	if err != nil {
 		return fmt.Errorf("parse cpk: %w", err)
 	}
 	return nil
+}
+
+// parseClaimPublicKey decodes the cpk claim of an identity token.
+//
+// Minecraft v1.26.40 started encoding the claim as a JSON Web Key. Earlier versions
+// encode it as a base64-encoded public key, which remains accepted by vanilla clients,
+// so both encodings are supported here.
+//
+// A nil public key is returned when the claim is absent, which is reported by
+// [tokenClaims.Validate].
+func parseClaimPublicKey(b json.RawMessage) (*ecdsa.PublicKey, error) {
+	if len(b) == 0 || bytes.Equal(b, []byte("null")) {
+		return nil, nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return nil, err
+		}
+		return parsePublicKey(s)
+	}
+	var key jose.JSONWebKey
+	if err := key.UnmarshalJSON(b); err != nil {
+		return nil, fmt.Errorf("parse JSON web key: %w", err)
+	}
+	publicKey, ok := key.Key.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("invalid key type: %T, expected *ecdsa.PublicKey", key.Key)
+	}
+	return publicKey, nil
 }
 
 // Validate checks the validity of the JWT claims populated in this struct.

--- a/identity_test.go
+++ b/identity_test.go
@@ -73,6 +73,70 @@ func TestTokenClaimsMarshalRejectsNilPublicKey(t *testing.T) {
 	}
 }
 
+func TestClaimPublicKeyAcceptsJSONWebKey(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	token, err := newIdentityTestTokenWithJSONWebKey(privateKey, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestTokenWithJSONWebKey() error = %v", err)
+	}
+	publicKey, err := claimPublicKey(token, true)
+	if err != nil {
+		t.Fatalf("claimPublicKey() error = %v", err)
+	}
+	if !publicKey.Equal(&privateKey.PublicKey) {
+		t.Fatal("claimPublicKey() returned a different public key")
+	}
+}
+
+func TestParseClaimPublicKey(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	encoded, err := encodePublicKey(&privateKey.PublicKey)
+	if err != nil {
+		t.Fatalf("encodePublicKey() error = %v", err)
+	}
+	base64Encoded, err := json.Marshal(encoded)
+	if err != nil {
+		t.Fatalf("marshal base64 cpk: %v", err)
+	}
+	webKeyEncoded, err := (&jose.JSONWebKey{Key: &privateKey.PublicKey}).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal JSON web key cpk: %v", err)
+	}
+
+	for name, claim := range map[string]json.RawMessage{
+		"base64":       base64Encoded,
+		"json web key": webKeyEncoded,
+	} {
+		t.Run(name, func(t *testing.T) {
+			publicKey, err := parseClaimPublicKey(claim)
+			if err != nil {
+				t.Fatalf("parseClaimPublicKey() error = %v", err)
+			}
+			if !publicKey.Equal(&privateKey.PublicKey) {
+				t.Fatal("parseClaimPublicKey() returned a different public key")
+			}
+		})
+	}
+
+	t.Run("absent", func(t *testing.T) {
+		for _, claim := range []json.RawMessage{nil, json.RawMessage("null")} {
+			publicKey, err := parseClaimPublicKey(claim)
+			if err != nil {
+				t.Fatalf("parseClaimPublicKey(%s) error = %v", claim, err)
+			}
+			if publicKey != nil {
+				t.Fatalf("parseClaimPublicKey(%s) = %v, want nil", claim, publicKey)
+			}
+		}
+	})
+
+	t.Run("unsupported key type", func(t *testing.T) {
+		if _, err := parseClaimPublicKey(json.RawMessage(`{"kty":"oct","k":"AAAA"}`)); err == nil {
+			t.Fatal("parseClaimPublicKey() succeeded for a symmetric key")
+		}
+	})
+}
+
 func newIdentityTestDescription() *description {
 	return &description{
 		dtls: webrtc.DTLSParameters{
@@ -105,5 +169,25 @@ func newIdentityTestToken(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (st
 			IssuedAt: jwt.NewNumericDate(issuedAt),
 		},
 		PublicKey: &privateKey.PublicKey,
+	}).Serialize()
+}
+
+// newIdentityTestTokenWithJSONWebKey signs a token that encodes its cpk claim as a
+// JSON Web Key, as Minecraft does since v1.26.40.
+func newIdentityTestTokenWithJSONWebKey(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (string, error) {
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, nil)
+	if err != nil {
+		return "", err
+	}
+	issuedAt := expiresAt.Add(-time.Minute)
+	return jwt.Signed(signer).Claims(struct {
+		jwt.Claims
+		PublicKey *jose.JSONWebKey `json:"cpk"`
+	}{
+		Claims: jwt.Claims{
+			Expiry:   jwt.NewNumericDate(expiresAt),
+			IssuedAt: jwt.NewNumericDate(issuedAt),
+		},
+		PublicKey: &jose.JSONWebKey{Key: &privateKey.PublicKey},
 	}).Serialize()
 }


### PR DESCRIPTION
## Summary

- Decode the `cpk` claim of an identity token from either a base64-encoded public key or a JSON Web Key.
- Keep encoding the claim in base64, which is what vanilla still emits.

## Why

Dialing a server currently fails during negotiation with:

```
verify server identity token: extract JWT claims: json: cannot unmarshal object into Go struct field .cpk of type string
```

`tokenClaims` decodes `cpk` as a string, but the claim may now be a JSON Web Key object instead.

Vanilla accepts both encodings: it first tries to read the claim as a JSON Web Key, reading `kty`
(`EC` or `RSA`) and, for `EC`, `crv` (`P-256`, `P-384` or `P-521`), and falls back to decoding the
claim as a base64-encoded public key when it is not an object. The JSON Web Key handling is absent
from Bedrock Dedicated Server 1.26.36.1 and present in 1.26.40.8 and 1.26.50.24, so it appears to
have been introduced in v1.26.40.

Only ECDSA keys are accepted here, since the `cpk` claim is used to verify the ES384 fingerprint
assertion carried in the 'a=identity' attribute.

## Checks

- `go test ./...`