### PR TITLE
identity.go: Cover cpk claim decoding with tests

### DIFF
--- a/identity.go
+++ b/identity.go
@@ -329,7 +329,7 @@ func parsePublicKey(data []byte) (*ecdsa.PublicKey, error) {
 	}
 	key, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("invalid key type: %T, expected *ecdsa.PublicKey", key)
+		return nil, fmt.Errorf("invalid key type: %T, expected *ecdsa.PublicKey", publicKey)
 	}
 	// Additional validation is left to the JOSE implementation.
 	return key, nil

--- a/identity_test.go
+++ b/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	cryptorand "crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -73,6 +74,87 @@ func TestTokenClaimsMarshalRejectsNilPublicKey(t *testing.T) {
 	}
 }
 
+func TestClaimPublicKeyAcceptsJSONWebKey(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	token, err := newIdentityTestTokenWithJSONWebKey(privateKey, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestTokenWithJSONWebKey() error = %v", err)
+	}
+	publicKey, err := claimPublicKey(token, true)
+	if err != nil {
+		t.Fatalf("claimPublicKey() error = %v", err)
+	}
+	if !publicKey.Equal(&privateKey.PublicKey) {
+		t.Fatal("claimPublicKey() returned a different public key")
+	}
+}
+
+func TestParsePublicKey(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	encoded, err := encodePublicKey(&privateKey.PublicKey)
+	if err != nil {
+		t.Fatalf("encodePublicKey() error = %v", err)
+	}
+	base64Encoded, err := json.Marshal(encoded)
+	if err != nil {
+		t.Fatalf("marshal base64 cpk: %v", err)
+	}
+	webKeyEncoded, err := (&jose.JSONWebKey{Key: &privateKey.PublicKey}).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal JSON web key cpk: %v", err)
+	}
+
+	for name, claim := range map[string][]byte{
+		"base64":       base64Encoded,
+		"json web key": webKeyEncoded,
+	} {
+		t.Run(name, func(t *testing.T) {
+			publicKey, err := parsePublicKey(claim)
+			if err != nil {
+				t.Fatalf("parsePublicKey() error = %v", err)
+			}
+			if !publicKey.Equal(&privateKey.PublicKey) {
+				t.Fatal("parsePublicKey() returned a different public key")
+			}
+		})
+	}
+
+	for name, claim := range map[string][]byte{
+		"absent":                 nil,
+		"null":                   []byte("null"),
+		"number":                 []byte("1"),
+		"malformed base64":       []byte(`"!!!"`),
+		"non-PKIX base64":        []byte(`"AAAA"`),
+		"symmetric json web key": []byte(`{"kty":"oct","k":"AAAA"}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parsePublicKey(claim); err == nil {
+				t.Fatalf("parsePublicKey(%s) succeeded, want error", claim)
+			}
+		})
+	}
+}
+
+// TestParsePublicKeyReportsKeyType ensures the error names the type that was actually
+// decoded, which is the only hint that a non-ECDSA key was received.
+func TestParsePublicKeyReportsKeyType(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	claim, err := (&jose.JSONWebKey{Key: &privateKey.PublicKey}).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal JSON web key cpk: %v", err)
+	}
+	_, err = parsePublicKey(claim)
+	if err == nil {
+		t.Fatal("parsePublicKey() succeeded for an RSA key")
+	}
+	if !strings.Contains(err.Error(), "*rsa.PublicKey") {
+		t.Fatalf("parsePublicKey() error = %v, want the decoded key type", err)
+	}
+}
+
 func newIdentityTestDescription() *description {
 	return &description{
 		dtls: webrtc.DTLSParameters{
@@ -105,5 +187,25 @@ func newIdentityTestToken(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (st
 			IssuedAt: jwt.NewNumericDate(issuedAt),
 		},
 		PublicKey: &privateKey.PublicKey,
+	}).Serialize()
+}
+
+// newIdentityTestTokenWithJSONWebKey signs a token that encodes its cpk claim as a
+// JSON Web Key, as Minecraft does since v1.26.40.
+func newIdentityTestTokenWithJSONWebKey(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (string, error) {
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, nil)
+	if err != nil {
+		return "", err
+	}
+	issuedAt := expiresAt.Add(-time.Minute)
+	return jwt.Signed(signer).Claims(struct {
+		jwt.Claims
+		PublicKey *jose.JSONWebKey `json:"cpk"`
+	}{
+		Claims: jwt.Claims{
+			Expiry:   jwt.NewNumericDate(expiresAt),
+			IssuedAt: jwt.NewNumericDate(issuedAt),
+		},
+		PublicKey: &jose.JSONWebKey{Key: &privateKey.PublicKey},
 	}).Serialize()
 }


### PR DESCRIPTION
## Summary

- Add test coverage for both encodings of the `cpk` claim, and for the inputs that must be rejected.
- Report the type that was actually decoded when the claim does not carry an ECDSA public key.

## Why

Follow-up to a128c03, which added JSON Web Key support but no tests. The added cases cover a
base64-encoded key, a JSON Web Key, an absent claim, `null`, a non-string/non-object value, a
malformed base64 string, a base64 string that is not a PKIX key, and a symmetric JSON Web Key.

The key type error formatted the type assertion result rather than the decoded key. That result
is always a nil `*ecdsa.PublicKey`, so the error read:

```
invalid key type: *ecdsa.PublicKey, expected *ecdsa.PublicKey
```

This is reachable now that JSON Web Keys are accepted, since vanilla also permits a `kty` of
`RSA`, and the message was the only indication of what was actually received. It now reads
`invalid key type: *rsa.PublicKey, expected *ecdsa.PublicKey`.

## Checks

- `go test ./...`