### PR TITLE
nethernet: Queue data channel sends with vanilla flow control

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -174,15 +174,14 @@ func (conn *Conn) Context() context.Context {
 	return conn.ctx
 }
 
-// Write writes the data into the 'ReliableDataChannel'. If the data exceeds 10000 bytes, it is split into
-// multiple segments. An error may be returned while writing a segment or if the Conn has been closed by [Conn.Close].
+// Write queues the data on the 'ReliableDataChannel'. See [Conn.Send].
 func (conn *Conn) Write(b []byte) (n int, err error) {
 	return conn.Send(b, MessageReliabilityReliable)
 }
 
-// Send writes the data into the data channel responsible for the given MessageReliability.
-// If the data exceeds 10,000 bytes, it is split into multiple segments. An error may be
-// returned while writing one or more segments or the Conn has been closed by [Conn.Close].
+// Send queues the data on the data channel for the given MessageReliability, split into
+// segments of at most the negotiated size. Delivery is asynchronous: a nil error means the
+// data was accepted in order, and it is sent as the channel opens and gains room.
 func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err error) {
 	select {
 	case <-conn.ctx.Done():
@@ -218,7 +217,7 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		remaining := totalSegments - 1
 		for i := 0; i < len(data); i += segmentSize {
 			frag := data[i:min(len(data), i+segmentSize)]
-			if err := d.Send(append([]byte{uint8(remaining)}, frag...)); err != nil {
+			if err := d.out.push(append([]byte{uint8(remaining)}, frag...)); err != nil {
 				return n, fmt.Errorf("write segment #%d: %w", totalSegments-1-remaining, closedWriteError(err))
 			}
 			n += len(frag)

--- a/conn.go
+++ b/conn.go
@@ -194,6 +194,8 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		if segmentSize == 0 {
 			segmentSize = maxMessageSize
 		}
+		// A header-prefixed segment must fit the send queue budget or it could never leave.
+		segmentSize = min(segmentSize, maxSendBufferedAmount-1)
 		if reliability == MessageReliabilityUnreliable && len(data) > segmentSize {
 			return 0, fmt.Errorf("data larger than %d (received: %d) cannot be sent over UnreliableDataChannel", segmentSize, len(data))
 		}

--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -1,6 +1,7 @@
 package nethernet
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -15,6 +16,84 @@ func TestDialListenerTrickleICE(t *testing.T) {
 
 func TestDialListenerNonTrickleICE(t *testing.T) {
 	testDialListener(t, true)
+}
+
+func TestSendQueueDrainsBeyondWebRTCBufferedAmountBudget(t *testing.T) {
+	client, server := newMemorySignalingPair("1", "2")
+	defer client.close()
+	defer server.close()
+
+	l, err := (ListenConfig{AllowAnonymous: true}).Listen(server)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer l.Close()
+
+	accepted := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	conn, err := (Dialer{}).DialContext(ctx, server.NetworkID(), client)
+	if err != nil {
+		t.Fatalf("DialContext() error = %v", err)
+	}
+	defer conn.Close()
+
+	var serverConn *Conn
+	select {
+	case acceptedConn := <-accepted:
+		serverConn = acceptedConn.(*Conn)
+	case err := <-acceptErr:
+		t.Fatalf("Accept() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("Accept() timed out: %v", ctx.Err())
+	}
+	defer serverConn.Close()
+
+	payload := make([]byte, maxSendBufferedAmount+maxMessageSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	received := make(chan []byte, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		packet, err := serverConn.ReadPacket()
+		if err != nil {
+			readErr <- err
+			return
+		}
+		received <- packet
+	}()
+
+	n, err := conn.Write(payload)
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("Write() = %d, want %d", n, len(payload))
+	}
+
+	select {
+	case got := <-received:
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("ReadPacket() returned %d corrupted bytes", len(got))
+		}
+	case err := <-readErr:
+		t.Fatalf("ReadPacket() error = %v", err)
+	case <-ctx.Done():
+		t.Fatalf("ReadPacket() timed out: %v", ctx.Err())
+	}
 }
 
 func TestDialedConnSurvivesSignalingCloseAfterNegotiation(t *testing.T) {

--- a/dial.go
+++ b/dial.go
@@ -355,7 +355,7 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 		if err != nil {
 			return fmt.Errorf("create %s: %w", r.Parameters().Label, err)
 		}
-		if existing := conn.storeChannel(r, wrapDataChannel(c, r, conn)); existing != nil {
+		if existing := conn.storeChannel(r, wrapDataChannel(c, r, conn, nil)); existing != nil {
 			return fmt.Errorf("data channel created for same reliability parameters: %q", r.Parameters().Label)
 		}
 	}

--- a/listener.go
+++ b/listener.go
@@ -450,17 +450,15 @@ func (l *Listener) handleOffer(signal *Signal) error {
 	c.sctp.OnDataChannel(func(channel *webrtc.DataChannel) {
 		for r := range messageReliabilityCapacity {
 			if r.Valid(channel) {
-				ch := wrapDataChannel(channel, r, c)
-				if existing := c.storeChannel(r, ch); existing != nil {
-					go c.close(fmt.Errorf("data channel created for same reliability parameters: %q", r.Parameters().Label))
-					return
-				}
-				channel.OnOpen(sync.OnceFunc(func() {
+				ch := wrapDataChannel(channel, r, c, sync.OnceFunc(func() {
 					// If all data channels have been opened by remote peer, we can signal that the connection is ready.
 					if opened.Add(1) == uint32(messageReliabilityCapacity) {
 						close(channelsReady)
 					}
 				}))
+				if existing := c.storeChannel(r, ch); existing != nil {
+					go c.close(fmt.Errorf("data channel created for same reliability parameters: %q", r.Parameters().Label))
+				}
 				return
 			}
 		}

--- a/listener.go
+++ b/listener.go
@@ -457,6 +457,8 @@ func (l *Listener) handleOffer(signal *Signal) error {
 					}
 				}))
 				if existing := c.storeChannel(r, ch); existing != nil {
+					// The duplicate is not tracked by the Conn, so release its queue here.
+					_ = ch.Close()
 					go c.close(fmt.Errorf("data channel created for same reliability parameters: %q", r.Parameters().Label))
 				}
 				return

--- a/message.go
+++ b/message.go
@@ -81,10 +81,14 @@ func (r MessageReliability) compareOptional(a, b *uint16) bool {
 
 // wrapDataChannel wraps a [webrtc.DataChannel] and sets up handlers to reconstruct
 // fragmented messages. Received message segments are reassembled and sent to packets
-// when all segments have arrived.
-func wrapDataChannel(channel *webrtc.DataChannel, reliability MessageReliability, conn *Conn) *dataChannel {
+// when all segments have arrived. onOpen, if non-nil, runs once the channel opens.
+func wrapDataChannel(channel *webrtc.DataChannel, reliability MessageReliability, conn *Conn, onOpen func()) *dataChannel {
 	ch := &dataChannel{
 		DataChannel: channel,
+		out: newSendQueue(channel, maxSendBufferedAmount, func(err error) {
+			// Closing tears down this queue too, so do it off the drain goroutine.
+			go conn.close(fmt.Errorf("nethernet: send on data channel %q: %w", channel.Label(), err))
+		}),
 		reliability: reliability,
 		// Previously, message.data was pre-allocated for all possible segments.
 		// Since most messages are smaller than 256KB and don't require fragmentation,
@@ -93,6 +97,12 @@ func wrapDataChannel(channel *webrtc.DataChannel, reliability MessageReliability
 		packets: make(chan []byte),
 		close:   make(chan struct{}),
 	}
+	ch.OnOpen(func() {
+		ch.out.signal()
+		if onOpen != nil {
+			onOpen()
+		}
+	})
 	ch.OnMessage(func(msg webrtc.DataChannelMessage) {
 		if err := ch.handleMessage(msg.Data); err != nil {
 			if errors.Is(err, net.ErrClosed) {
@@ -119,6 +129,9 @@ func wrapDataChannel(channel *webrtc.DataChannel, reliability MessageReliability
 // within a Conn. It contains the fields necessary for handling multiple segments received in the embedded [webrtc.DataChannel].
 type dataChannel struct {
 	*webrtc.DataChannel
+
+	// out delivers outbound messages once the channel is open and has room.
+	out *sendQueue
 
 	// An embedded message contains the buffer that holds the segments received
 	// to now and the count of the last segment count.
@@ -212,6 +225,7 @@ func (c *dataChannel) handleMessage(b []byte) error {
 func (c *dataChannel) Close() (err error) {
 	c.once.Do(func() {
 		close(c.close)
+		c.out.close(net.ErrClosed)
 		c.messageMu.Lock()
 		clear(c.data)
 		c.messageMu.Unlock()

--- a/sendqueue.go
+++ b/sendqueue.go
@@ -1,0 +1,141 @@
+package nethernet
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// sendChannel is the part of a [webrtc.DataChannel] that sendQueue drives.
+type sendChannel interface {
+	Send([]byte) error
+	BufferedAmount() uint64
+	SetBufferedAmountLowThreshold(uint64)
+	OnBufferedAmountLow(func())
+	ReadyState() webrtc.DataChannelState
+}
+
+var _ sendChannel = (*webrtc.DataChannel)(nil)
+
+// maxSendBufferedAmount is the most a data channel may hold in its send buffer
+// before the next queued message is held back, matching the vanilla limit.
+const maxSendBufferedAmount = 16 << 20
+
+// sendQueue holds outbound messages in FIFO order and hands each one to the
+// data channel once it is open and has room for it. The queue itself is
+// unbounded, like vanilla; only the data channel's send buffer is capped.
+type sendQueue struct {
+	channel     sendChannel
+	maxBuffered uint64
+	// fail is called once with the error that made the channel unusable.
+	fail func(error)
+	// wake nudges the drain goroutine; it never blocks the sender.
+	wake chan struct{}
+
+	mu     sync.Mutex
+	queue  [][]byte
+	closed error
+}
+
+func newSendQueue(channel sendChannel, maxBuffered uint64, fail func(error)) *sendQueue {
+	q := &sendQueue{
+		channel:     channel,
+		maxBuffered: maxBuffered,
+		fail:        fail,
+		wake:        make(chan struct{}, 1),
+	}
+	channel.OnBufferedAmountLow(q.signal)
+	go q.run()
+	return q
+}
+
+// push queues b for delivery. It returns the closing error once the queue is closed.
+func (q *sendQueue) push(b []byte) error {
+	if size := uint64(len(b)); size > q.maxBuffered {
+		return fmt.Errorf("message exceeds data channel send buffer: %d > %d", size, q.maxBuffered)
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed != nil {
+		return q.closed
+	}
+	q.queue = append(q.queue, b)
+	q.signal()
+	return nil
+}
+
+// signal asks the drain goroutine to retry, e.g. when the channel opened or
+// its buffered amount dropped.
+func (q *sendQueue) signal() {
+	select {
+	case q.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (q *sendQueue) run() {
+	for range q.wake {
+		if q.drain() != nil {
+			return
+		}
+	}
+}
+
+// close drops queued messages and makes further pushes return cause.
+func (q *sendQueue) close(cause error) {
+	q.mu.Lock()
+	q.closeLocked(cause)
+	q.mu.Unlock()
+	q.signal()
+}
+
+func (q *sendQueue) closeLocked(cause error) {
+	if q.closed == nil {
+		q.closed = cause
+	}
+	q.queue = nil
+}
+
+// drain sends queued messages in order while the channel is open and the next
+// message fits its send buffer. It returns the closing error once closed.
+func (q *sendQueue) drain() error {
+	for {
+		q.mu.Lock()
+		if q.closed != nil {
+			defer q.mu.Unlock()
+			return q.closed
+		}
+		if len(q.queue) == 0 {
+			q.mu.Unlock()
+			return nil
+		}
+		b := q.queue[0]
+		q.mu.Unlock()
+
+		if q.channel.ReadyState() != webrtc.DataChannelStateOpen {
+			return nil
+		}
+		// Arm the low-water callback before checking so a drop between the
+		// two cannot be missed.
+		threshold := q.maxBuffered - uint64(len(b))
+		q.channel.SetBufferedAmountLowThreshold(threshold)
+		if q.channel.BufferedAmount() > threshold {
+			return nil
+		}
+		if err := q.channel.Send(b); err != nil {
+			q.close(err)
+			if q.fail != nil {
+				q.fail(err)
+			}
+			return err
+		}
+
+		q.mu.Lock()
+		if q.closed == nil {
+			q.queue[0] = nil
+			q.queue = q.queue[1:]
+		}
+		q.mu.Unlock()
+	}
+}

--- a/sendqueue_test.go
+++ b/sendqueue_test.go
@@ -1,0 +1,362 @@
+package nethernet
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// fakeSendChannel implements sendChannel deterministically for tests. Its
+// buffered amount grows on Send and is released manually with release, which
+// invokes the OnBufferedAmountLow callback with the same edge-triggered
+// semantics as Pion: only when the buffered amount crosses from above the
+// threshold to at or below it.
+type fakeSendChannel struct {
+	mu        sync.Mutex
+	buffered  uint64
+	threshold uint64
+	onLow     func()
+	state     webrtc.DataChannelState
+	sendErr   error
+	sent      [][]byte
+
+	// budget, when non-zero, is the buffered-amount budget every Send must
+	// respect; violations counts sends that would exceed it.
+	budget     uint64
+	violations int
+
+	// sentCh receives each message as it is passed to Send.
+	sentCh chan []byte
+}
+
+func newFakeSendChannel() *fakeSendChannel {
+	return &fakeSendChannel{
+		state:  webrtc.DataChannelStateOpen,
+		sentCh: make(chan []byte, 16),
+	}
+}
+
+func (f *fakeSendChannel) Send(b []byte) error {
+	f.mu.Lock()
+	if f.sendErr != nil {
+		f.mu.Unlock()
+		return f.sendErr
+	}
+	if f.budget > 0 && f.buffered+uint64(len(b)) > f.budget {
+		f.violations++
+	}
+	f.buffered += uint64(len(b))
+	f.sent = append(f.sent, b)
+	f.mu.Unlock()
+	f.sentCh <- b
+	return nil
+}
+
+func (f *fakeSendChannel) BufferedAmount() uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.buffered
+}
+
+func (f *fakeSendChannel) SetBufferedAmountLowThreshold(th uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.threshold = th
+}
+
+func (f *fakeSendChannel) OnBufferedAmountLow(fn func()) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onLow = fn
+}
+
+func (f *fakeSendChannel) ReadyState() webrtc.DataChannelState {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.state
+}
+
+// open flips the channel to open like Pion would, after which the caller
+// signals the queue as the dataChannel's OnOpen hook does.
+func (f *fakeSendChannel) open() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.state = webrtc.DataChannelStateOpen
+}
+
+// release acknowledges n buffered bytes like a remote peer would, invoking
+// the registered OnBufferedAmountLow callback on the threshold crossing.
+func (f *fakeSendChannel) release(n uint64) {
+	f.mu.Lock()
+	from := f.buffered
+	f.buffered -= n
+	fire := f.onLow != nil && from > f.threshold && f.buffered <= f.threshold
+	fn := f.onLow
+	f.mu.Unlock()
+	if fire {
+		fn()
+	}
+}
+
+func (f *fakeSendChannel) setBuffered(n uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.buffered = n
+}
+
+func (f *fakeSendChannel) sentCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sent)
+}
+
+func (f *fakeSendChannel) bufferedAmountLowThreshold() uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.threshold
+}
+
+// wait fails the test if ch does not become ready in time.
+func wait[T any](t *testing.T, ch <-chan T, what string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		panic("unreachable")
+	}
+}
+
+func TestSendQueueBufferedAmountBudget(t *testing.T) {
+	fake := newFakeSendChannel()
+	fake.budget = 100
+	q := newSendQueue(fake, 100, nil)
+	defer q.close(net.ErrClosed)
+
+	msgs := make([][]byte, 5)
+	for i := range msgs {
+		msgs[i] = bytes.Repeat([]byte{byte(i)}, 40)
+		if err := q.push(msgs[i]); err != nil {
+			t.Fatalf("push(#%d) error = %v, want nil", i, err)
+		}
+	}
+	// Only the first two messages fit the budget (80 of 100 bytes).
+	wait(t, fake.sentCh, "message #0")
+	wait(t, fake.sentCh, "message #1")
+	if got := fake.bufferedAmountLowThreshold(); got != 60 {
+		t.Fatalf("buffered amount low threshold = %d, want 60", got)
+	}
+
+	// Acknowledging 40 bytes crosses the threshold (80 -> 40) and resumes
+	// draining for exactly one more message.
+	fake.release(40)
+	wait(t, fake.sentCh, "message #2")
+
+	// Acknowledging the rest (80 -> 0) resumes draining for the remainder.
+	fake.release(80)
+	wait(t, fake.sentCh, "message #3")
+	wait(t, fake.sentCh, "message #4")
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.violations != 0 {
+		t.Fatalf("%d sends exceeded the buffered-amount budget", fake.violations)
+	}
+	if len(fake.sent) != len(msgs) {
+		t.Fatalf("sent %d messages, want %d", len(fake.sent), len(msgs))
+	}
+	for i, want := range msgs {
+		if !bytes.Equal(fake.sent[i], want) {
+			t.Fatalf("sent[%d] = %v, want %v", i, fake.sent[i][0], want[0])
+		}
+	}
+}
+
+func TestSendQueueFullSizeMessageResumesAtCapacity(t *testing.T) {
+	fake := newFakeSendChannel()
+	fake.budget = maxSendBufferedAmount
+	fake.setBuffered(maxSendBufferedAmount)
+	q := newSendQueue(fake, maxSendBufferedAmount, nil)
+	defer q.close(net.ErrClosed)
+
+	msg := make([]byte, maxMessageSize+1)
+	if err := q.push(msg); err != nil {
+		t.Fatalf("push error = %v, want nil", err)
+	}
+	if got := fake.sentCount(); got != 0 {
+		t.Fatalf("sent count = %d, want 0", got)
+	}
+
+	fake.release(uint64(len(msg)))
+	if got := wait(t, fake.sentCh, "full-size message"); len(got) != len(msg) {
+		t.Fatalf("sent %d bytes, want %d", len(got), len(msg))
+	}
+}
+
+func TestSendQueueWaitsForOpen(t *testing.T) {
+	fake := newFakeSendChannel()
+	fake.state = webrtc.DataChannelStateConnecting
+	q := newSendQueue(fake, maxSendBufferedAmount, nil)
+	defer q.close(net.ErrClosed)
+
+	if err := q.push([]byte("queued")); err != nil {
+		t.Fatalf("push error = %v, want nil", err)
+	}
+	if got := fake.sentCount(); got != 0 {
+		t.Fatalf("sent count = %d, want 0", got)
+	}
+
+	fake.open()
+	q.signal()
+	if got := wait(t, fake.sentCh, "queued message"); !bytes.Equal(got, []byte("queued")) {
+		t.Fatalf("sent %q, want queued", got)
+	}
+}
+
+func TestSendQueueRetainsMessagesBeyondBufferedAmountBudget(t *testing.T) {
+	fake := newFakeSendChannel()
+	fake.budget = 100
+	fake.setBuffered(200) // Over the budget: the drainer pauses immediately.
+	q := newSendQueue(fake, 100, nil)
+	defer q.close(net.ErrClosed)
+
+	msgs := [][]byte{
+		bytes.Repeat([]byte{0}, 60),
+		bytes.Repeat([]byte{1}, 30),
+		bytes.Repeat([]byte{2}, 20),
+	}
+	for i, msg := range msgs {
+		if err := q.push(msg); err != nil {
+			t.Fatalf("push(#%d) error = %v, want nil", i, err)
+		}
+	}
+	if got := fake.sentCount(); got != 0 {
+		t.Fatalf("sent count = %d, want 0", got)
+	}
+
+	// The outer FIFO may retain more data than the channel's buffered-amount
+	// budget. Delivery resumes in order as room becomes available.
+	fake.release(160)
+	if got := wait(t, fake.sentCh, "message #0"); !bytes.Equal(got, msgs[0]) {
+		t.Fatalf("sent message #0 = %v, want %v", got, msgs[0])
+	}
+	fake.release(30)
+	if got := wait(t, fake.sentCh, "message #1"); !bytes.Equal(got, msgs[1]) {
+		t.Fatalf("sent message #1 = %v, want %v", got, msgs[1])
+	}
+	fake.release(20)
+	if got := wait(t, fake.sentCh, "message #2"); !bytes.Equal(got, msgs[2]) {
+		t.Fatalf("sent message #2 = %v, want %v", got, msgs[2])
+	}
+}
+
+func TestSendQueueCloseDropsPendingMessages(t *testing.T) {
+	fake := newFakeSendChannel()
+	fake.setBuffered(200) // Over the budget: the drainer pauses immediately.
+	q := newSendQueue(fake, 100, nil)
+
+	if err := q.push(make([]byte, 40)); err != nil {
+		t.Fatalf("push(40 bytes) error = %v, want nil", err)
+	}
+
+	q.close(net.ErrClosed)
+
+	if err := q.push(make([]byte, 1)); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("push after close error = %v, want net.ErrClosed", err)
+	}
+	if n := fake.sentCount(); n != 0 {
+		t.Fatalf("Send called %d times, want 0", n)
+	}
+}
+
+func TestSendQueueSendErrorClosesQueue(t *testing.T) {
+	fake := newFakeSendChannel()
+	sendErr := errors.New("send failed")
+	fake.sendErr = sendErr
+	failed := make(chan error, 1)
+
+	q := newSendQueue(fake, 100, func(err error) {
+		failed <- err
+	})
+	if err := q.push([]byte("doomed")); err != nil {
+		t.Fatalf("push error = %v, want nil", err)
+	}
+	if err := wait(t, failed, "failure callback"); !errors.Is(err, sendErr) {
+		t.Fatalf("failure callback error = %v, want %v", err, sendErr)
+	}
+
+	if err := q.push([]byte("next")); !errors.Is(err, sendErr) {
+		t.Fatalf("push after send failure error = %v, want %v", err, sendErr)
+	}
+}
+
+func TestConnSendFragmentsInOrder(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	fake := newFakeSendChannel()
+	fake.budget = maxSendBufferedAmount
+	q := newSendQueue(fake, maxSendBufferedAmount, nil)
+	defer q.close(net.ErrClosed)
+
+	conn := &Conn{ctx: ctx}
+	conn.storeChannel(MessageReliabilityReliable, &dataChannel{out: q})
+
+	data := make([]byte, 2*maxMessageSize+5)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	n, err := conn.Write(data)
+	if err != nil {
+		t.Fatalf("Write error = %v, want nil", err)
+	}
+	if n != len(data) {
+		t.Fatalf("Write = %d, want %d", n, len(data))
+	}
+
+	var payload []byte
+	for _, wantRemaining := range []byte{2, 1, 0} {
+		frag := wait(t, fake.sentCh, "fragment")
+		if len(frag) == 0 || frag[0] != wantRemaining {
+			t.Fatalf("fragment prefix = %v, want %d", frag[:1], wantRemaining)
+		}
+		payload = append(payload, frag[1:]...)
+	}
+	if !bytes.Equal(payload, data) {
+		t.Fatalf("reassembled payload does not match written data")
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.violations != 0 {
+		t.Fatalf("%d sends exceeded the buffered-amount budget", fake.violations)
+	}
+}
+
+func TestConnWriteQueuesWhileDataChannelIsFull(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	fake := newFakeSendChannel()
+	fake.setBuffered(200) // Over the budget: the drainer pauses immediately.
+	q := newSendQueue(fake, 100, nil)
+	defer q.close(net.ErrClosed)
+
+	conn := &Conn{ctx: ctx}
+	conn.storeChannel(MessageReliabilityReliable, &dataChannel{out: q})
+
+	for i := range 2 {
+		if _, err := conn.Write(make([]byte, 90)); err != nil {
+			t.Fatalf("Write(#%d) error = %v, want nil", i, err)
+		}
+	}
+	if got := fake.sentCount(); got != 0 {
+		t.Fatalf("sent count = %d, want 0", got)
+	}
+}

--- a/sendqueue_test.go
+++ b/sendqueue_test.go
@@ -360,3 +360,41 @@ func TestConnWriteQueuesWhileDataChannelIsFull(t *testing.T) {
 		t.Fatalf("sent count = %d, want 0", got)
 	}
 }
+
+func TestConnSendClampsSegmentsToSendQueueBudget(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	fake := newFakeSendChannel()
+	fake.budget = maxSendBufferedAmount
+	q := newSendQueue(fake, maxSendBufferedAmount, nil)
+	defer q.close(net.ErrClosed)
+
+	conn := &Conn{ctx: ctx}
+	conn.maxSegmentPayload.Store(2 * maxSendBufferedAmount)
+	conn.storeChannel(MessageReliabilityReliable, &dataChannel{out: q})
+
+	data := make([]byte, maxSendBufferedAmount+10)
+	n, err := conn.Write(data)
+	if err != nil {
+		t.Fatalf("Write error = %v, want nil", err)
+	}
+	if n != len(data) {
+		t.Fatalf("Write = %d, want %d", n, len(data))
+	}
+
+	frag := wait(t, fake.sentCh, "first fragment")
+	if len(frag) != maxSendBufferedAmount || frag[0] != 1 {
+		t.Fatalf("first fragment = %d bytes with prefix %d, want %d bytes with prefix 1", len(frag), frag[0], maxSendBufferedAmount)
+	}
+	fake.release(uint64(len(frag)))
+	frag = wait(t, fake.sentCh, "last fragment")
+	if len(frag) != 12 || frag[0] != 0 {
+		t.Fatalf("last fragment = %d bytes with prefix %d, want 12 bytes with prefix 0", len(frag), frag[0])
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.violations != 0 {
+		t.Fatalf("%d sends exceeded the buffered-amount budget", fake.violations)
+	}
+}


### PR DESCRIPTION
## Summary

- Give each data channel an unbounded FIFO send queue; `Send`/`Write` return once the segments are queued
- Drain queued messages in order while the channel is open and the next message keeps the WebRTC send buffer within its 16 MiB limit
- Resume draining when the channel opens or its buffered amount drops below the threshold for the next message
- Close the connection if the data channel rejects a send
- Stop each queue when its connection is canceled, including queues created during teardown

## Why

Writes went directly to the WebRTC data channel, so a send issued before the channel opened, or once its internal buffer was full, failed instead of being retained. Vanilla queues outbound messages and retries them as the channel gains room; this matches that behaviour.

## Checks

- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go test -race ./...`
- `go test -race -count=50 -run 'SendQueue|ConnSend|ConnWrite' .`
- Dialer-to-Listener transfer larger than the WebRTC send-buffer limit (`TestSendQueueDrainsBeyondWebRTCBufferedAmountBudget`)