### PR TITLE
endpoint: document the client transport probe order on Handler

### DIFF
--- a/endpoint/handler.go
+++ b/endpoint/handler.go
@@ -129,6 +129,14 @@ func ServeTLS(address string, certFile, keyFile string) (*Handler, error) {
 // Currently, Handler implements the following endpoints:
 //   - GET /v1/join (ping)
 //   - POST /v1/join/{networkID} (WebRTC negotiation)
+//
+// On an address join a Bedrock client discovers this endpoint by sending the
+// GET /v1/join ping to each candidate URL in order, stopping at the first that
+// responds: https://host:port, https://host (443), http://host:port, then
+// http://host (80). An explicit port collapses the list to the https/http
+// variants on that port. If none respond the client falls back to RakNet, so a
+// server that serves this Handler is reached over NetherNet in preference to a
+// RakNet listener on the same address.
 type Handler struct {
 	// pending tracks connection that are currently waiting for an SDP answer.
 	// Each key identifies the connection with network ID and connection ID, and


### PR DESCRIPTION
## Summary

Documents, on the `Handler` type, how a Bedrock client discovers the NetherNet signaling endpoint that this package serves. The behavior is client-side, but this `endpoint` package owns the server side of the handshake (`GET /v1/join` ping + `POST /v1/join/{networkID}` negotiation), so it is the natural home for the protocol knowledge rather than duplicating it in every consumer.

On an address join the client pings `GET /v1/join` at each candidate URL in order, stopping at the first that responds:

1. `https://host:port`
2. `https://host` (443)
3. `http://host:port`
4. `http://host` (80)

An explicit port collapses the list to the https/http variants on that port. If none respond the client falls back to RakNet — so a server that serves this `Handler` is reached over NetherNet in preference to a RakNet listener on the same address.