### PR TITLE
conn: Match vanilla negotiated message sizing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -499,23 +499,8 @@ func (conn *Conn) segmentPayloadSize() int {
 
 // updateMaxSegmentPayload reads the established SCTP limit and stores the
 // space available after the one-byte NetherNet fragment header.
-func (conn *Conn) updateMaxSegmentPayload() error {
-	max := conn.sctp.GetCapabilities().MaxMessageSize
-	payload, err := segmentPayloadSizeFromSCTP(max)
-	if err != nil {
-		return err
-	}
-	conn.maxSegmentPayload.Store(payload)
-	return nil
-}
-
-// segmentPayloadSizeFromSCTP removes the one-byte NetherNet fragment header
-// from an SCTP message-size limit.
-func segmentPayloadSizeFromSCTP(max uint32) (uint32, error) {
-	if max <= 1 {
-		return 0, fmt.Errorf("negotiated SCTP max message size must exceed one byte: %d", max)
-	}
-	return max - 1, nil
+func (conn *Conn) updateMaxSegmentPayload() {
+	conn.maxSegmentPayload.Store(conn.sctp.GetCapabilities().MaxMessageSize - 1)
 }
 
 // parseDescription parses a [sdp.SessionDescription] signaled from a remote connection.
@@ -589,6 +574,9 @@ func parseDescription(d *sdp.SessionDescription) (*description, error) {
 	maxMessageSize, err := strconv.ParseUint(attr, 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("parse max-message-size attribute as uint32: %w", err)
+	}
+	if maxMessageSize <= 1 {
+		return nil, fmt.Errorf("max-message-size attribute must exceed one byte: %d", maxMessageSize)
 	}
 
 	var candidates []webrtc.ICECandidate

--- a/conn.go
+++ b/conn.go
@@ -497,12 +497,6 @@ func (conn *Conn) segmentPayloadSize() int {
 	return maxMessageSize
 }
 
-// updateMaxSegmentPayload reads the established SCTP limit and stores the
-// space available after the one-byte NetherNet fragment header.
-func (conn *Conn) updateMaxSegmentPayload() {
-	conn.maxSegmentPayload.Store(conn.sctp.GetCapabilities().MaxMessageSize - 1)
-}
-
 // parseDescription parses a [sdp.SessionDescription] signaled from a remote connection.
 // It transforms the fields of the [sdp.SessionDescription] into a description, which can be
 // used to start ICE, DTLS, and SCTP transports for a Conn.

--- a/conn.go
+++ b/conn.go
@@ -191,7 +191,10 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		if reliability >= messageReliabilityCapacity {
 			return 0, fmt.Errorf("invalid message reliability: %d", reliability)
 		}
-		segmentSize := conn.segmentPayloadSize()
+		segmentSize := int(conn.maxSegmentPayload.Load())
+		if segmentSize == 0 {
+			segmentSize = maxMessageSize
+		}
 		if reliability == MessageReliabilityUnreliable && len(data) > segmentSize {
 			return 0, fmt.Errorf("data larger than %d (received: %d) cannot be sent over UnreliableDataChannel", segmentSize, len(data))
 		}
@@ -204,7 +207,10 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		// Each segment is prefixed with a uint8 remaining-segment counter that starts
 		// at totalSegments-1 and decrements to 0 for the final segment. Vanilla
 		// limits the total number of segments to math.MaxUint8 (255).
-		totalSegments := messageFragmentCount(len(data), segmentSize)
+		totalSegments := 0
+		if len(data) != 0 {
+			totalSegments = (len(data)-1)/segmentSize + 1
+		}
 		if totalSegments > math.MaxUint8 {
 			return 0, fmt.Errorf("data too large: %d bytes requires %d segments (max %d)", len(data), totalSegments, math.MaxUint8)
 		}
@@ -220,15 +226,6 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		}
 		return n, nil
 	}
-}
-
-// messageFragmentCount returns how many data-channel messages are needed to
-// carry a packet at the given payload size.
-func messageFragmentCount(size, segmentSize int) int {
-	if size == 0 {
-		return 0
-	}
-	return (size-1)/segmentSize + 1
 }
 
 // closedWriteError wraps the given cause with [net.ErrClosed] so callers
@@ -487,15 +484,6 @@ func (conn *Conn) addRemoteCandidate(candidate webrtc.ICECandidate) error {
 // This is 256KB (262144 bytes) minus 1 byte for the segment counter,
 // matching the 'a=max-message-size' value in the SDP sent by vanilla peer connections.
 const maxMessageSize = 262143
-
-// segmentPayloadSize returns the negotiated fragment payload size. It uses the
-// standard NetherNet size before transport negotiation has finished.
-func (conn *Conn) segmentPayloadSize() int {
-	if size := conn.maxSegmentPayload.Load(); size != 0 {
-		return int(size)
-	}
-	return maxMessageSize
-}
 
 // parseDescription parses a [sdp.SessionDescription] signaled from a remote connection.
 // It transforms the fields of the [sdp.SessionDescription] into a description, which can be

--- a/conn.go
+++ b/conn.go
@@ -73,6 +73,9 @@ type Conn struct {
 	channels [messageReliabilityCapacity]*dataChannel
 	// channelsMu guards channels from concurrent read-write access during startup and closure.
 	channelsMu sync.RWMutex
+	// maxSegmentPayload is the negotiated SCTP message size minus the one-byte
+	// NetherNet fragment header.
+	maxSegmentPayload atomic.Uint32
 
 	readMu  sync.Mutex
 	readBuf []byte
@@ -188,8 +191,9 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		if reliability >= messageReliabilityCapacity {
 			return 0, fmt.Errorf("invalid message reliability: %d", reliability)
 		}
-		if reliability == MessageReliabilityUnreliable && len(data) > maxMessageSize {
-			return 0, fmt.Errorf("data larger than %d (received: %d) cannot be sent over UnreliableDataChannel", maxMessageSize, len(data))
+		segmentSize := conn.segmentPayloadSize()
+		if reliability == MessageReliabilityUnreliable && len(data) > segmentSize {
+			return 0, fmt.Errorf("data larger than %d (received: %d) cannot be sent over UnreliableDataChannel", segmentSize, len(data))
 		}
 		d := conn.channel(reliability)
 
@@ -198,17 +202,16 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		defer d.write.Unlock()
 
 		// Each segment is prefixed with a uint8 remaining-segment counter that starts
-		// at totalSegments-1 and decrements to 0 for the final segment. This limits
-		// the maximum number of segments to math.MaxUint8+1 (256).
-		const maxSegments = math.MaxUint8 + 1
-		totalSegments := (len(data) + maxMessageSize - 1) / maxMessageSize
-		if totalSegments > maxSegments {
-			return 0, fmt.Errorf("data too large: %d bytes requires %d segments (max %d)", len(data), totalSegments, maxSegments)
+		// at totalSegments-1 and decrements to 0 for the final segment. Vanilla
+		// limits the total number of segments to math.MaxUint8 (255).
+		totalSegments := messageFragmentCount(len(data), segmentSize)
+		if totalSegments > math.MaxUint8 {
+			return 0, fmt.Errorf("data too large: %d bytes requires %d segments (max %d)", len(data), totalSegments, math.MaxUint8)
 		}
 
 		remaining := totalSegments - 1
-		for i := 0; i < len(data); i += maxMessageSize {
-			frag := data[i:min(len(data), i+maxMessageSize)]
+		for i := 0; i < len(data); i += segmentSize {
+			frag := data[i:min(len(data), i+segmentSize)]
 			if err := d.Send(append([]byte{uint8(remaining)}, frag...)); err != nil {
 				return n, fmt.Errorf("write segment #%d: %w", totalSegments-1-remaining, closedWriteError(err))
 			}
@@ -217,6 +220,13 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 		}
 		return n, nil
 	}
+}
+
+func messageFragmentCount(size, segmentSize int) int {
+	if size == 0 {
+		return 0
+	}
+	return (size-1)/segmentSize + 1
 }
 
 // closedWriteError wraps the given cause with [net.ErrClosed] so callers
@@ -475,6 +485,30 @@ func (conn *Conn) addRemoteCandidate(candidate webrtc.ICECandidate) error {
 // This is 256KB (262144 bytes) minus 1 byte for the segment counter,
 // matching the 'a=max-message-size' value in the SDP sent by vanilla peer connections.
 const maxMessageSize = 262143
+
+func (conn *Conn) segmentPayloadSize() int {
+	if size := conn.maxSegmentPayload.Load(); size != 0 {
+		return int(size)
+	}
+	return maxMessageSize
+}
+
+func (conn *Conn) updateMaxSegmentPayload() error {
+	max := conn.sctp.GetCapabilities().MaxMessageSize
+	payload, err := segmentPayloadSizeFromSCTP(max)
+	if err != nil {
+		return err
+	}
+	conn.maxSegmentPayload.Store(payload)
+	return nil
+}
+
+func segmentPayloadSizeFromSCTP(max uint32) (uint32, error) {
+	if max <= 1 {
+		return 0, fmt.Errorf("negotiated SCTP max message size must exceed one byte: %d", max)
+	}
+	return max - 1, nil
+}
 
 // parseDescription parses a [sdp.SessionDescription] signaled from a remote connection.
 // It transforms the fields of the [sdp.SessionDescription] into a description, which can be
@@ -832,6 +866,7 @@ func newConn(api *webrtc.API, gathererOpts webrtc.ICEGatherOptions, id uint64, n
 		localNetworkID: localNetworkID,
 	}
 	c.ctx, c.cancel = context.WithCancelCause(context.Background())
+	c.maxSegmentPayload.Store(maxMessageSize)
 	c.handleTransports()
 	return c, nil
 }

--- a/conn.go
+++ b/conn.go
@@ -222,6 +222,8 @@ func (conn *Conn) Send(data []byte, reliability MessageReliability) (n int, err 
 	}
 }
 
+// messageFragmentCount returns how many data-channel messages are needed to
+// carry a packet at the given payload size.
 func messageFragmentCount(size, segmentSize int) int {
 	if size == 0 {
 		return 0
@@ -486,6 +488,8 @@ func (conn *Conn) addRemoteCandidate(candidate webrtc.ICECandidate) error {
 // matching the 'a=max-message-size' value in the SDP sent by vanilla peer connections.
 const maxMessageSize = 262143
 
+// segmentPayloadSize returns the negotiated fragment payload size. It uses the
+// standard NetherNet size before transport negotiation has finished.
 func (conn *Conn) segmentPayloadSize() int {
 	if size := conn.maxSegmentPayload.Load(); size != 0 {
 		return int(size)
@@ -493,6 +497,8 @@ func (conn *Conn) segmentPayloadSize() int {
 	return maxMessageSize
 }
 
+// updateMaxSegmentPayload reads the established SCTP limit and stores the
+// space available after the one-byte NetherNet fragment header.
 func (conn *Conn) updateMaxSegmentPayload() error {
 	max := conn.sctp.GetCapabilities().MaxMessageSize
 	payload, err := segmentPayloadSizeFromSCTP(max)
@@ -503,6 +509,8 @@ func (conn *Conn) updateMaxSegmentPayload() error {
 	return nil
 }
 
+// segmentPayloadSizeFromSCTP removes the one-byte NetherNet fragment header
+// from an SCTP message-size limit.
 func segmentPayloadSizeFromSCTP(max uint32) (uint32, error) {
 	if max <= 1 {
 		return 0, fmt.Errorf("negotiated SCTP max message size must exceed one byte: %d", max)

--- a/conn_test.go
+++ b/conn_test.go
@@ -80,3 +80,58 @@ func TestIsTerminalICEState(t *testing.T) {
 		}
 	}
 }
+
+func TestMessageFragmentCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		size        int
+		segmentSize int
+		want        int
+	}{
+		{name: "empty", segmentSize: maxMessageSize},
+		{name: "single", size: maxMessageSize, segmentSize: maxMessageSize, want: 1},
+		{name: "two", size: maxMessageSize + 1, segmentSize: maxMessageSize, want: 2},
+		{name: "vanilla maximum", size: maxMessageSize * 255, segmentSize: maxMessageSize, want: 255},
+		{name: "over vanilla maximum", size: maxMessageSize*255 + 1, segmentSize: maxMessageSize, want: 256},
+		{name: "negotiated size", size: 1999, segmentSize: 999, want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := messageFragmentCount(tt.size, tt.segmentSize); got != tt.want {
+				t.Fatalf("messageFragmentCount(%d, %d) = %d, want %d", tt.size, tt.segmentSize, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnSegmentPayloadSizeDefaultsToVanilla(t *testing.T) {
+	var conn Conn
+	if got := conn.segmentPayloadSize(); got != maxMessageSize {
+		t.Fatalf("segmentPayloadSize() = %d, want %d", got, maxMessageSize)
+	}
+	conn.maxSegmentPayload.Store(999)
+	if got := conn.segmentPayloadSize(); got != 999 {
+		t.Fatalf("segmentPayloadSize() = %d, want 999", got)
+	}
+}
+
+func TestSegmentPayloadSizeFromSCTP(t *testing.T) {
+	for _, max := range []uint32{0, 1} {
+		if _, err := segmentPayloadSizeFromSCTP(max); err == nil {
+			t.Fatalf("segmentPayloadSizeFromSCTP(%d) error = nil, want error", max)
+		}
+	}
+	for max, want := range map[uint32]uint32{
+		2:       1,
+		65_535:  65_534,
+		262_144: maxMessageSize,
+	} {
+		got, err := segmentPayloadSizeFromSCTP(max)
+		if err != nil {
+			t.Fatalf("segmentPayloadSizeFromSCTP(%d) error = %v", max, err)
+		}
+		if got != want {
+			t.Fatalf("segmentPayloadSizeFromSCTP(%d) = %d, want %d", max, got, want)
+		}
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -82,40 +82,6 @@ func TestIsTerminalICEState(t *testing.T) {
 	}
 }
 
-func TestMessageFragmentCount(t *testing.T) {
-	tests := []struct {
-		name        string
-		size        int
-		segmentSize int
-		want        int
-	}{
-		{name: "empty", segmentSize: maxMessageSize},
-		{name: "single", size: maxMessageSize, segmentSize: maxMessageSize, want: 1},
-		{name: "two", size: maxMessageSize + 1, segmentSize: maxMessageSize, want: 2},
-		{name: "vanilla maximum", size: maxMessageSize * 255, segmentSize: maxMessageSize, want: 255},
-		{name: "over vanilla maximum", size: maxMessageSize*255 + 1, segmentSize: maxMessageSize, want: 256},
-		{name: "negotiated size", size: 1999, segmentSize: 999, want: 3},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := messageFragmentCount(tt.size, tt.segmentSize); got != tt.want {
-				t.Fatalf("messageFragmentCount(%d, %d) = %d, want %d", tt.size, tt.segmentSize, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestConnSegmentPayloadSizeDefaultsToVanilla(t *testing.T) {
-	var conn Conn
-	if got := conn.segmentPayloadSize(); got != maxMessageSize {
-		t.Fatalf("segmentPayloadSize() = %d, want %d", got, maxMessageSize)
-	}
-	conn.maxSegmentPayload.Store(999)
-	if got := conn.segmentPayloadSize(); got != 999 {
-		t.Fatalf("segmentPayloadSize() = %d, want 999", got)
-	}
-}
-
 func TestParseDescriptionRejectsMessageSizesWithoutFragmentPayload(t *testing.T) {
 	for _, max := range []string{"0", "1"} {
 		t.Run(max, func(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/pion/sdp/v3"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -115,23 +116,22 @@ func TestConnSegmentPayloadSizeDefaultsToVanilla(t *testing.T) {
 	}
 }
 
-func TestSegmentPayloadSizeFromSCTP(t *testing.T) {
-	for _, max := range []uint32{0, 1} {
-		if _, err := segmentPayloadSizeFromSCTP(max); err == nil {
-			t.Fatalf("segmentPayloadSizeFromSCTP(%d) error = nil, want error", max)
-		}
-	}
-	for max, want := range map[uint32]uint32{
-		2:       1,
-		65_535:  65_534,
-		262_144: maxMessageSize,
-	} {
-		got, err := segmentPayloadSizeFromSCTP(max)
-		if err != nil {
-			t.Fatalf("segmentPayloadSizeFromSCTP(%d) error = %v", max, err)
-		}
-		if got != want {
-			t.Fatalf("segmentPayloadSizeFromSCTP(%d) = %d, want %d", max, got, want)
-		}
+func TestParseDescriptionRejectsMessageSizesWithoutFragmentPayload(t *testing.T) {
+	for _, max := range []string{"0", "1"} {
+		t.Run(max, func(t *testing.T) {
+			media := &sdp.MediaDescription{}
+			media.WithValueAttribute("ice-ufrag", "ufrag")
+			media.WithValueAttribute("ice-pwd", "password")
+			media.WithFingerprint("sha-256", "fingerprint")
+			media.WithValueAttribute("setup", "actpass")
+			media.WithValueAttribute("max-message-size", max)
+
+			_, err := parseDescription(&sdp.SessionDescription{
+				MediaDescriptions: []*sdp.MediaDescription{media},
+			})
+			if err == nil {
+				t.Fatalf("parseDescription() error = nil, want error for max-message-size %s", max)
+			}
+		})
 	}
 }

--- a/dial.go
+++ b/dial.go
@@ -349,7 +349,7 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 	}); err != nil {
 		return fmt.Errorf("start SCTP: %w", err)
 	}
-	conn.updateMaxSegmentPayload()
+	conn.maxSegmentPayload.Store(conn.sctp.GetCapabilities().MaxMessageSize - 1)
 	for r := range messageReliabilityCapacity {
 		c, err := d.API.NewDataChannel(conn.sctp, r.Parameters())
 		if err != nil {

--- a/dial.go
+++ b/dial.go
@@ -349,9 +349,7 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 	}); err != nil {
 		return fmt.Errorf("start SCTP: %w", err)
 	}
-	if err := conn.updateMaxSegmentPayload(); err != nil {
-		return fmt.Errorf("configure NetherNet message size: %w", err)
-	}
+	conn.updateMaxSegmentPayload()
 	for r := range messageReliabilityCapacity {
 		c, err := d.API.NewDataChannel(conn.sctp, r.Parameters())
 		if err != nil {

--- a/dial.go
+++ b/dial.go
@@ -349,6 +349,9 @@ func (d Dialer) startTransports(ctx context.Context, conn *Conn, desc *descripti
 	}); err != nil {
 		return fmt.Errorf("start SCTP: %w", err)
 	}
+	if err := conn.updateMaxSegmentPayload(); err != nil {
+		return fmt.Errorf("configure NetherNet message size: %w", err)
+	}
 	for r := range messageReliabilityCapacity {
 		c, err := d.API.NewDataChannel(conn.sctp, r.Parameters())
 		if err != nil {

--- a/listener.go
+++ b/listener.go
@@ -625,7 +625,7 @@ func (l *Listener) startTransports(ctx context.Context, conn *Conn, d *descripti
 	}); err != nil {
 		return fmt.Errorf("start SCTP: %w", err)
 	}
-	conn.updateMaxSegmentPayload()
+	conn.maxSegmentPayload.Store(conn.sctp.GetCapabilities().MaxMessageSize - 1)
 
 	return l.waitForChannelsReady(ctx, conn, channelsReady)
 }

--- a/listener.go
+++ b/listener.go
@@ -625,9 +625,7 @@ func (l *Listener) startTransports(ctx context.Context, conn *Conn, d *descripti
 	}); err != nil {
 		return fmt.Errorf("start SCTP: %w", err)
 	}
-	if err := conn.updateMaxSegmentPayload(); err != nil {
-		return fmt.Errorf("configure NetherNet message size: %w", err)
-	}
+	conn.updateMaxSegmentPayload()
 
 	return l.waitForChannelsReady(ctx, conn, channelsReady)
 }

--- a/listener.go
+++ b/listener.go
@@ -625,6 +625,9 @@ func (l *Listener) startTransports(ctx context.Context, conn *Conn, d *descripti
 	}); err != nil {
 		return fmt.Errorf("start SCTP: %w", err)
 	}
+	if err := conn.updateMaxSegmentPayload(); err != nil {
+		return fmt.Errorf("configure NetherNet message size: %w", err)
+	}
 
 	return l.waitForChannelsReady(ctx, conn, channelsReady)
 }


### PR DESCRIPTION
## Summary

- derive the NetherNet fragment payload size from the established SCTP association
- retain the vanilla `0x3ffff` payload size as the pre-negotiation default
- cap reliable messages at vanilla’s 255-fragment limit
- apply the negotiated size to unreliable-message validation and fragmentation