### PR TITLE
listener: Enforce connection address ownership

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -390,6 +390,12 @@ func (l *Listener) handleOffer(signal *Signal) error {
 			_ = c.Close()
 		}
 	}()
+	if !l.registerConnection(c) {
+		return wrapSignalError(
+			fmt.Errorf("connection already exists for %s", c.remoteAddr()),
+			ErrorCodeIncomingConnectionIgnored,
+		)
+	}
 	disableTrickleICE := shouldDisableTrickleICE(l.conf.DisableTrickleICE, l.signaling)
 	if disableTrickleICE {
 		c.description.candidates, err = c.gatherCandidates(ctx)
@@ -483,7 +489,6 @@ func (l *Listener) handleOffer(signal *Signal) error {
 		}
 	}
 
-	l.connections.Store(c.remoteAddr().String(), c)
 	go l.handleConn(c, desc, channelsReady)
 	established = true
 	return nil
@@ -518,9 +523,16 @@ func (l *Listener) handleSignal(signal *Signal) error {
 	return conn.(*Conn).handleSignal(signal)
 }
 
+// registerConnection gives conn ownership of its remote address if no other
+// connection is already negotiating or established for it.
+func (l *Listener) registerConnection(conn *Conn) bool {
+	_, loaded := l.connections.LoadOrStore(conn.remoteAddr().String(), conn)
+	return !loaded
+}
+
 // handleClose deletes the Conn from the Listener, since it is closed and can no longer be negotiated.
 func (l *Listener) handleClose(conn *Conn) {
-	l.connections.Delete(conn.remoteAddr().String())
+	l.connections.CompareAndDelete(conn.remoteAddr().String(), conn)
 }
 
 // log extends the [slog.Logger] from [ListenConfig.Log] with an additional [slog.Attr] of "src" with the

--- a/listener_test.go
+++ b/listener_test.go
@@ -31,3 +31,32 @@ func TestListenerWaitForChannelsReadyReturnsNilWhenReady(t *testing.T) {
 		t.Fatalf("waitForChannelsReady() error = %v, want nil", err)
 	}
 }
+
+func TestListenerConnectionOwnership(t *testing.T) {
+	l := &Listener{}
+	first := &Conn{id: 7, networkID: "remote"}
+	duplicate := &Conn{id: 7, networkID: "remote"}
+	key := first.remoteAddr().String()
+
+	if !l.registerConnection(first) {
+		t.Fatal("registerConnection(first) = false, want true")
+	}
+	if l.registerConnection(duplicate) {
+		t.Fatal("registerConnection(duplicate) = true, want false")
+	}
+	if got, ok := l.connections.Load(key); !ok || got != first {
+		t.Fatalf("connections.Load(%q) = (%p, %t), want (%p, true)", key, got, ok, first)
+	}
+
+	// Cleanup for a rejected duplicate must not remove the connection that owns
+	// the address.
+	l.handleClose(duplicate)
+	if got, ok := l.connections.Load(key); !ok || got != first {
+		t.Fatalf("connections.Load(%q) after duplicate close = (%p, %t), want (%p, true)", key, got, ok, first)
+	}
+
+	l.handleClose(first)
+	if _, ok := l.connections.Load(key); ok {
+		t.Fatalf("connections.Load(%q) after owner close succeeded, want missing", key)
+	}
+}


### PR DESCRIPTION
## Summary

- reserve each remote network/connection ID pair for a single connection
- reject duplicate offers while the original connection is negotiating or active
- remove connection mappings only when the closing connection owns them

## Why

Unconditional map replacement and deletion allowed cleanup from an older or rejected connection to remove the active connection mapped at the same address. Explicit ownership keeps signal routing stable and makes duplicate-offer handling deterministic.