### PR TITLE
discovery/packet_message.go: Read message data past the declared length

### DIFF
--- a/discovery/packet_message.go
+++ b/discovery/packet_message.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -27,6 +28,13 @@ func (pk *MessagePacket) Read(r io.Reader) error {
 	data, err := readBytes[uint32](r)
 	if err != nil {
 		return fmt.Errorf("read data: %w", err)
+	}
+	// Vanilla may write more data than the length prefix declares, with the
+	// rest of the signal continuing right after the declared range. Read the
+	// remaining bytes as part of the data instead of leaving them for the
+	// trailing-bytes check in Unmarshal.
+	if buf, ok := r.(*bytes.Buffer); ok && buf.Len() > 0 {
+		data = append(data, buf.Next(buf.Len())...)
 	}
 	pk.Data = string(data)
 	return nil

--- a/discovery/packet_message.go
+++ b/discovery/packet_message.go
@@ -34,7 +34,7 @@ func (pk *MessagePacket) Read(r io.Reader) error {
 	// remaining bytes as part of the data instead of leaving them for the
 	// trailing-bytes check in Unmarshal.
 	if buf, ok := r.(*bytes.Buffer); ok && buf.Len() > 0 {
-		data = append(data, buf.Next(buf.Len())...)
+		data = append(data, buf.Bytes()...)
 	}
 	pk.Data = string(data)
 	return nil

--- a/discovery/packet_test.go
+++ b/discovery/packet_test.go
@@ -119,6 +119,27 @@ func TestMarshalWritesInclusiveLengthAndRoundTrips(t *testing.T) {
 	}
 }
 
+func TestUnmarshalMessageDataPastDeclaredLength(t *testing.T) {
+	const declared = "CONNECTREQUEST 1 v=0\r\n"
+	const rest = "a=candidate:1 1 udp 1 192.168.1.2 50000 typ host\r\n"
+
+	pk, _, err := Unmarshal(rawPacket(IDMessagePacket, func(body *bytes.Buffer) {
+		_ = binary.Write(body, binary.LittleEndian, uint64(2))
+		writeBytes[uint32](body, []byte(declared))
+		body.WriteString(rest)
+	}))
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	msg, ok := pk.(*MessagePacket)
+	if !ok {
+		t.Fatalf("Unmarshal() packet = %T, want *MessagePacket", pk)
+	}
+	if msg.Data != declared+rest {
+		t.Fatalf("Unmarshal() data = %q, want %q", msg.Data, declared+rest)
+	}
+}
+
 func rawPacket(packetID uint16, write func(*bytes.Buffer)) []byte {
 	body := &bytes.Buffer{}
 	(&Header{PacketID: packetID, SenderID: 1}).Write(body)


### PR DESCRIPTION
Joining a LAN world through the discovery listener fails for some vanilla clients: the listener drops every incoming MESSAGE with `error handling packet: decode: unread 489 bytes`, so offers never get through and the client eventually errors out.

Captured several of these offers. The length prefix does not match the payload: it says 1140 bytes in every capture, the actual data is 1510 to 1626 bytes (8 or 9 ICE candidates), and the remaining bytes continue the signal mid-SDP with no separator. Looks like a fixed value rather than the real length, so Unmarshal rejects any offer above that size. Phones gather enough candidates to go over it easily.

Read now takes the remaining buffered bytes as part of the data instead of leaving them for the trailing-bytes check. Senders that declare the full length (including Marshal) drain the buffer either way, so nothing changes for them. Tested against a vanilla 1.26.40 client; negotiation completes and the join works.
