### PR TITLE
nethernet: skip temporal validation for server identities

### DIFF
--- a/identity.go
+++ b/identity.go
@@ -39,6 +39,8 @@ type Identity struct {
 	Domain string
 }
 
+const serverIdentityIssuedAtLeeway = 2 * time.Minute
+
 // sign signs the DTLS fingerprints included in the given local description using
 // the [Identity.PrivateKey], and returns an identityData that can be embedded
 // to the description.
@@ -86,8 +88,14 @@ func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 	if err := t.UnsafeClaimsWithoutVerification(&claims); err != nil {
 		return nil, fmt.Errorf("extract JWT claims: %w", err)
 	}
-	if err := claims.Validate(jwt.Expected{Time: time.Now()}); err != nil {
-		return nil, fmt.Errorf("validate JWT claims: %w", err)
+	var validationErr error
+	if selfSigned {
+		validationErr = validateServerIdentityClaims(claims, time.Now())
+	} else {
+		validationErr = claims.Validate(jwt.Expected{Time: time.Now()})
+	}
+	if validationErr != nil {
+		return nil, fmt.Errorf("validate JWT claims: %w", validationErr)
 	}
 	if selfSigned {
 		// Verify that server identity tokens are self-signed using the corresponding
@@ -97,6 +105,21 @@ func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 		}
 	}
 	return claims.PublicKey, nil
+}
+
+// validateServerIdentityClaims retains go-jose's default leeway for expiry and
+// not-before claims while allowing a modest amount of clock skew for the
+// issued-at timestamp of a remote server identity.
+func validateServerIdentityClaims(claims tokenClaims, now time.Time) error {
+	issuedAt := claims.IssuedAt
+	claims.IssuedAt = nil
+	if err := claims.Validate(jwt.Expected{Time: now}); err != nil {
+		return err
+	}
+	if issuedAt != nil && now.Add(serverIdentityIssuedAtLeeway).Before(issuedAt.Time()) {
+		return jwt.ErrIssuedInTheFuture
+	}
+	return nil
 }
 
 // GenerateServerIdentity creates a new server Identity using the provided private key.

--- a/identity.go
+++ b/identity.go
@@ -39,8 +39,6 @@ type Identity struct {
 	Domain string
 }
 
-const serverIdentityIssuedAtLeeway = 2 * time.Minute
-
 // sign signs the DTLS fingerprints included in the given local description using
 // the [Identity.PrivateKey], and returns an identityData that can be embedded
 // to the description.
@@ -73,7 +71,8 @@ func (i Identity) sign(desc *description) error {
 
 // claimPublicKey extracts and validates the public key from the 'cpk' claim in the JWT token.
 // If selfSigned is true, it verifies that the token is self-signed with the corresponding private key.
-// It also validates standard JWT claims such as expiration time.
+// Client identity tokens have their standard JWT claims validated, while server identity
+// tokens do not have their temporal claims validated to match Bedrock behavior.
 func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 	t, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{
 		// Server identity tokens are self-signed using ES384
@@ -88,14 +87,10 @@ func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 	if err := t.UnsafeClaimsWithoutVerification(&claims); err != nil {
 		return nil, fmt.Errorf("extract JWT claims: %w", err)
 	}
-	var validationErr error
-	if selfSigned {
-		validationErr = validateServerIdentityClaims(claims, time.Now())
-	} else {
-		validationErr = claims.Validate(jwt.Expected{Time: time.Now()})
-	}
-	if validationErr != nil {
-		return nil, fmt.Errorf("validate JWT claims: %w", validationErr)
+	if !selfSigned {
+		if err := claims.Validate(jwt.Expected{Time: time.Now()}); err != nil {
+			return nil, fmt.Errorf("validate JWT claims: %w", err)
+		}
 	}
 	if selfSigned {
 		// Verify that server identity tokens are self-signed using the corresponding
@@ -105,21 +100,6 @@ func claimPublicKey(token string, selfSigned bool) (*ecdsa.PublicKey, error) {
 		}
 	}
 	return claims.PublicKey, nil
-}
-
-// validateServerIdentityClaims retains go-jose's default leeway for expiry and
-// not-before claims while allowing a modest amount of clock skew for the
-// issued-at timestamp of a remote server identity.
-func validateServerIdentityClaims(claims tokenClaims, now time.Time) error {
-	issuedAt := claims.IssuedAt
-	claims.IssuedAt = nil
-	if err := claims.Validate(jwt.Expected{Time: now}); err != nil {
-		return err
-	}
-	if issuedAt != nil && now.Add(serverIdentityIssuedAtLeeway).Before(issuedAt.Time()) {
-		return jwt.ErrIssuedInTheFuture
-	}
-	return nil
 }
 
 // GenerateServerIdentity creates a new server Identity using the provided private key.

--- a/identity_test.go
+++ b/identity_test.go
@@ -57,38 +57,30 @@ func TestIdentityVerifyRejectsTamperedFingerprint(t *testing.T) {
 	}
 }
 
-func TestClaimPublicKeyRejectsExpiredToken(t *testing.T) {
+func TestClaimPublicKeyRejectsExpiredClientIdentity(t *testing.T) {
 	privateKey := newIdentityTestKey(t)
 	token, err := newIdentityTestToken(privateKey, time.Now().Add(-time.Minute))
 	if err != nil {
 		t.Fatalf("newIdentityTestToken() error = %v", err)
 	}
-	if _, err := claimPublicKey(token, true); err == nil {
-		t.Fatal("claimPublicKey() succeeded for expired token")
+	if _, err := claimPublicKey(token, false); err == nil {
+		t.Fatal("claimPublicKey() succeeded for expired client identity")
 	}
 }
 
-func TestClaimPublicKeyAllowsSmallFutureIssuedAtSkewForServerIdentity(t *testing.T) {
+func TestClaimPublicKeyIgnoresTemporalClaimsForServerIdentity(t *testing.T) {
 	privateKey := newIdentityTestKey(t)
-	issuedAt := time.Now().Add(90 * time.Second)
-	token, err := newIdentityTestTokenAt(privateKey, issuedAt, issuedAt.Add(time.Minute))
+	now := time.Now()
+	token, err := newIdentityTestTokenWithClaims(privateKey, jwt.Claims{
+		Expiry:    jwt.NewNumericDate(now.Add(-time.Minute)),
+		IssuedAt:  jwt.NewNumericDate(now.Add(90 * time.Second)),
+		NotBefore: jwt.NewNumericDate(now.Add(90 * time.Second)),
+	})
 	if err != nil {
-		t.Fatalf("newIdentityTestTokenAt() error = %v", err)
+		t.Fatalf("newIdentityTestTokenWithClaims() error = %v", err)
 	}
 	if _, err := claimPublicKey(token, true); err != nil {
-		t.Fatalf("claimPublicKey() rejected small future iat skew: %v", err)
-	}
-}
-
-func TestClaimPublicKeyRejectsLargeFutureIssuedAtSkewForServerIdentity(t *testing.T) {
-	privateKey := newIdentityTestKey(t)
-	issuedAt := time.Now().Add(2*time.Minute + 30*time.Second)
-	token, err := newIdentityTestTokenAt(privateKey, issuedAt, issuedAt.Add(time.Minute))
-	if err != nil {
-		t.Fatalf("newIdentityTestTokenAt() error = %v", err)
-	}
-	if _, err := claimPublicKey(token, true); !errors.Is(err, jwt.ErrIssuedInTheFuture) {
-		t.Fatalf("claimPublicKey() error = %v, want future iat error", err)
+		t.Fatalf("claimPublicKey() rejected server identity temporal claims: %v", err)
 	}
 }
 
@@ -217,15 +209,19 @@ func newIdentityTestToken(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (st
 }
 
 func newIdentityTestTokenAt(privateKey *ecdsa.PrivateKey, issuedAt, expiresAt time.Time) (string, error) {
+	return newIdentityTestTokenWithClaims(privateKey, jwt.Claims{
+		Expiry:   jwt.NewNumericDate(expiresAt),
+		IssuedAt: jwt.NewNumericDate(issuedAt),
+	})
+}
+
+func newIdentityTestTokenWithClaims(privateKey *ecdsa.PrivateKey, claims jwt.Claims) (string, error) {
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, nil)
 	if err != nil {
 		return "", err
 	}
 	return jwt.Signed(signer).Claims(tokenClaims{
-		Claims: jwt.Claims{
-			Expiry:   jwt.NewNumericDate(expiresAt),
-			IssuedAt: jwt.NewNumericDate(issuedAt),
-		},
+		Claims:    claims,
 		PublicKey: &privateKey.PublicKey,
 	}).Serialize()
 }

--- a/identity_test.go
+++ b/identity_test.go
@@ -6,6 +6,7 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +65,42 @@ func TestClaimPublicKeyRejectsExpiredToken(t *testing.T) {
 	}
 	if _, err := claimPublicKey(token, true); err == nil {
 		t.Fatal("claimPublicKey() succeeded for expired token")
+	}
+}
+
+func TestClaimPublicKeyAllowsSmallFutureIssuedAtSkewForServerIdentity(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	issuedAt := time.Now().Add(90 * time.Second)
+	token, err := newIdentityTestTokenAt(privateKey, issuedAt, issuedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestTokenAt() error = %v", err)
+	}
+	if _, err := claimPublicKey(token, true); err != nil {
+		t.Fatalf("claimPublicKey() rejected small future iat skew: %v", err)
+	}
+}
+
+func TestClaimPublicKeyRejectsLargeFutureIssuedAtSkewForServerIdentity(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	issuedAt := time.Now().Add(2*time.Minute + 30*time.Second)
+	token, err := newIdentityTestTokenAt(privateKey, issuedAt, issuedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestTokenAt() error = %v", err)
+	}
+	if _, err := claimPublicKey(token, true); !errors.Is(err, jwt.ErrIssuedInTheFuture) {
+		t.Fatalf("claimPublicKey() error = %v, want future iat error", err)
+	}
+}
+
+func TestClaimPublicKeyRejectsFutureIssuedAtSkewForClientIdentity(t *testing.T) {
+	privateKey := newIdentityTestKey(t)
+	issuedAt := time.Now().Add(90 * time.Second)
+	token, err := newIdentityTestTokenAt(privateKey, issuedAt, issuedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("newIdentityTestTokenAt() error = %v", err)
+	}
+	if _, err := claimPublicKey(token, false); !errors.Is(err, jwt.ErrIssuedInTheFuture) {
+		t.Fatalf("claimPublicKey() error = %v, want future iat error", err)
 	}
 }
 
@@ -176,11 +213,14 @@ func newIdentityTestKey(t *testing.T) *ecdsa.PrivateKey {
 }
 
 func newIdentityTestToken(privateKey *ecdsa.PrivateKey, expiresAt time.Time) (string, error) {
+	return newIdentityTestTokenAt(privateKey, expiresAt.Add(-time.Minute), expiresAt)
+}
+
+func newIdentityTestTokenAt(privateKey *ecdsa.PrivateKey, issuedAt, expiresAt time.Time) (string, error) {
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES384, Key: privateKey}, nil)
 	if err != nil {
 		return "", err
 	}
-	issuedAt := expiresAt.Add(-time.Minute)
 	return jwt.Signed(signer).Claims(tokenClaims{
 		Claims: jwt.Claims{
 			Expiry:   jwt.NewNumericDate(expiresAt),


### PR DESCRIPTION
## Problem

Bedrock server identity tokens contain standard temporal claims, but the Bedrock client does not validate those claims when accepting the server identity. Valid server connections can therefore be rejected by go-nethernet solely because of an expired, not-yet-valid, or future-issued claim.

## Change

- Skip temporal JWT claim validation for self-signed server identity tokens.
- Continue requiring a valid cpk claim and a valid self-signature for server identities.
- Keep full standard JWT claim validation for client identity tokens.

## Tests

- Accept a server identity with expired, future-issued, and not-yet-valid claims.
- Continue rejecting an expired client identity.
- Continue rejecting a client identity with a future iat.

Focused tests: go test ./... with the TestClaimPublicKey, TestIdentity, and TestParsePublicKey filters.