### PR TITLE
listener: Preserve transport failure details during cleanup

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -625,15 +625,7 @@ func (n *listenerNegotiator) finaliseConn(conn *Conn, d *description, channelsRe
 	}
 
 	defer func() {
-		if err != nil {
-			if cause := context.Cause(conn.ctx); cause != nil {
-				err = cause
-			}
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				// Report the timeout through negotiate, which owns the error reply.
-				err = &signalError{code: ErrorCodeNegotiationTimeoutWaitingForAccept, underlying: err}
-			}
-		}
+		err = finaliseConnError(ctx, conn.ctx, err)
 	}()
 
 	select {
@@ -660,6 +652,25 @@ func (n *listenerNegotiator) finaliseConn(conn *Conn, d *description, channelsRe
 		}
 		return nil
 	}
+}
+
+// finaliseConnError restores the connection cause when a wait returns a generic
+// cancellation error and adds the handshake timeout code when its deadline expired.
+// Concrete transport errors keep their original details and wrapping.
+func finaliseConnError(ctx, connCtx context.Context, err error) error {
+	if err != nil {
+		switch err {
+		case context.Canceled, context.DeadlineExceeded, net.ErrClosed:
+			if cause := context.Cause(connCtx); cause != nil {
+				err = cause
+			}
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			// Report the timeout through negotiate, which owns the error reply.
+			err = &signalError{code: ErrorCodeNegotiationTimeoutWaitingForAccept, underlying: err}
+		}
+	}
+	return err
 }
 
 // startTransports starts ICE as [webrtc.ICERoleControlled], then starts DTLS

--- a/listener.go
+++ b/listener.go
@@ -625,7 +625,18 @@ func (n *listenerNegotiator) finaliseConn(conn *Conn, d *description, channelsRe
 	}
 
 	defer func() {
-		err = finaliseConnError(ctx, conn.ctx, err)
+		if err != nil {
+			switch err {
+			case context.Canceled, context.DeadlineExceeded, net.ErrClosed:
+				if cause := context.Cause(conn.ctx); cause != nil {
+					err = cause
+				}
+			}
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				// Report the timeout through negotiate, which owns the error reply.
+				err = &signalError{code: ErrorCodeNegotiationTimeoutWaitingForAccept, underlying: err}
+			}
+		}
 	}()
 
 	select {
@@ -652,25 +663,6 @@ func (n *listenerNegotiator) finaliseConn(conn *Conn, d *description, channelsRe
 		}
 		return nil
 	}
-}
-
-// finaliseConnError restores the connection cause when a wait returns a generic
-// cancellation error and adds the handshake timeout code when its deadline expired.
-// Concrete transport errors keep their original details and wrapping.
-func finaliseConnError(ctx, connCtx context.Context, err error) error {
-	if err != nil {
-		switch err {
-		case context.Canceled, context.DeadlineExceeded, net.ErrClosed:
-			if cause := context.Cause(connCtx); cause != nil {
-				err = cause
-			}
-		}
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			// Report the timeout through negotiate, which owns the error reply.
-			err = &signalError{code: ErrorCodeNegotiationTimeoutWaitingForAccept, underlying: err}
-		}
-	}
-	return err
 }
 
 // startTransports starts ICE as [webrtc.ICERoleControlled], then starts DTLS

--- a/listener_test.go
+++ b/listener_test.go
@@ -84,6 +84,30 @@ func TestListenerTimeoutReplyUsesConnContext(t *testing.T) {
 	}
 }
 
+func TestFinaliseConnErrorPreservesTransportDetails(t *testing.T) {
+	closedCtx, cancel := context.WithCancelCause(context.Background())
+	cause := errors.New("DTLS transport entered failed state")
+	cancel(cause)
+	for _, failure := range []error{
+		fmt.Errorf("start transports: %w", errors.New("remote fingerprint mismatch")),
+		fmt.Errorf("start transports: %w", context.Canceled),
+		fmt.Errorf("start transports: %w", context.DeadlineExceeded),
+		fmt.Errorf("start transports: %w", net.ErrClosed),
+	} {
+		if got := finaliseConnError(context.Background(), closedCtx, failure); got != failure {
+			t.Errorf("finaliseConnError() = %v, want original error %v", got, failure)
+		}
+	}
+	for _, failure := range []error{context.Canceled, context.DeadlineExceeded, net.ErrClosed} {
+		if got := finaliseConnError(context.Background(), closedCtx, failure); got != cause {
+			t.Errorf("finaliseConnError(%v) = %v, want connection cause %v", failure, got, cause)
+		}
+	}
+	if got := finaliseConnError(context.Background(), closedCtx, nil); got != nil {
+		t.Fatalf("successful finalisation changed to failure: %v", got)
+	}
+}
+
 func TestListenerFinaliseConnPreservesFailureCause(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	want := errors.New("remote negotiation failed")

--- a/listener_test.go
+++ b/listener_test.go
@@ -84,30 +84,6 @@ func TestListenerTimeoutReplyUsesConnContext(t *testing.T) {
 	}
 }
 
-func TestFinaliseConnErrorPreservesTransportDetails(t *testing.T) {
-	closedCtx, cancel := context.WithCancelCause(context.Background())
-	cause := errors.New("DTLS transport entered failed state")
-	cancel(cause)
-	for _, failure := range []error{
-		fmt.Errorf("start transports: %w", errors.New("remote fingerprint mismatch")),
-		fmt.Errorf("start transports: %w", context.Canceled),
-		fmt.Errorf("start transports: %w", context.DeadlineExceeded),
-		fmt.Errorf("start transports: %w", net.ErrClosed),
-	} {
-		if got := finaliseConnError(context.Background(), closedCtx, failure); got != failure {
-			t.Errorf("finaliseConnError() = %v, want original error %v", got, failure)
-		}
-	}
-	for _, failure := range []error{context.Canceled, context.DeadlineExceeded, net.ErrClosed} {
-		if got := finaliseConnError(context.Background(), closedCtx, failure); got != cause {
-			t.Errorf("finaliseConnError(%v) = %v, want connection cause %v", failure, got, cause)
-		}
-	}
-	if got := finaliseConnError(context.Background(), closedCtx, nil); got != nil {
-		t.Fatalf("successful finalisation changed to failure: %v", got)
-	}
-}
-
 func TestListenerFinaliseConnPreservesFailureCause(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	want := errors.New("remote negotiation failed")

--- a/signal.go
+++ b/signal.go
@@ -15,6 +15,7 @@ type Signaling interface {
 	// Signal sends a Signal to a remote network referenced by [Signal.NetworkID].
 	// The [context.Context] is used to cancel waiting for the acknowledgement from
 	// the signaling server as soon as possible.
+	// Signal may be called concurrently, including for the same connection.
 	Signal(ctx context.Context, signal *Signal) error
 
 	// Notify registers n for receiving incoming signals from remote networks.


### PR DESCRIPTION
When transport startup fails while its connection closes, finalisation can replace the detailed transport error with a generic closure cause. Preserve concrete errors and their wrapping; use the connection cause only for bare cancellation errors. Keep this handling in the existing defer. Handshake timeout signaling keeps its existing behavior.

Also document that `Signaling.Signal` may run concurrently, including for the same connection.

Targets `feature/concurrent-negotiation` as a follow-up to #49. Validation: `go test -race ./...` and `go vet ./...` pass, including the existing finalisation cause and timeout tests.
