### PR TITLE
signal: Match vanilla parsing before connection dispatch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -424,13 +424,9 @@ func (conn *Conn) handleSignal(signal *Signal) error {
 			return err
 		}
 	case SignalTypeError:
-		code, err := strconv.ParseUint(signal.Data, 10, 32)
+		code, err := parseSignalErrorCode(signal.Data)
 		if err != nil {
-			e := fmt.Errorf("parse error code: %w", err)
-			if err := conn.close(fmt.Errorf("nethernet: remote peer notified connection failure (invalid code: %q)", signal.Data)); err != nil {
-				e = errors.Join(fmt.Errorf("close: %w", err), e)
-			}
-			return e
+			return fmt.Errorf("parse error code: %w", err)
 		}
 		if err := conn.close(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code)); err != nil {
 			return fmt.Errorf("close: %w", err)

--- a/conn_negotiation_test.go
+++ b/conn_negotiation_test.go
@@ -430,3 +430,50 @@ func (s *memorySignaling) signalCount(signalType string) int {
 	defer s.stats.mu.Unlock()
 	return s.stats.counts[signalType]
 }
+
+func TestRemoteErrorsAfterNegotiation(t *testing.T) {
+	for _, receiver := range []string{"listener", "dialer"} {
+		t.Run(receiver, func(t *testing.T) {
+			client, server := newMemorySignalingPair("client", "server")
+			t.Cleanup(client.close)
+			t.Cleanup(server.close)
+			l, clientConn, serverConn := dialAcceptedListener(t, client, server)
+			waitListenerState(t, l, 0, 1)
+			conn, sender, receiverSignaling := serverConn, client, server
+			if receiver == "dialer" {
+				conn, sender, receiverSignaling = clientConn, server, client
+			}
+			addr := conn.LocalAddr().(*Addr)
+			for _, signal := range []Signal{
+				{Type: SignalTypeError, Data: "invalid"},
+				{Type: SignalTypeError, Data: "2147483648"},
+				{Type: "UNKNOWN", Data: "data"},
+			} {
+				signal.NetworkID, signal.ConnectionID = addr.NetworkID, addr.ConnectionID
+				if err := sender.Signal(t.Context(), &signal); err != nil {
+					t.Fatal(err)
+				}
+			}
+			checkConnPayload(t, clientConn, serverConn, []byte("client remains connected"))
+			checkConnPayload(t, serverConn, clientConn, []byte("server remains connected"))
+			if got := receiverSignaling.signalCount(SignalTypeError); got != 0 {
+				t.Fatalf("receiver sent %d error replies to malformed signals", got)
+			}
+			// A valid error follows the discarded signals on the same signaling path.
+			if err := sender.Signal(t.Context(), &Signal{
+				Type: SignalTypeError, NetworkID: addr.NetworkID, ConnectionID: addr.ConnectionID, Data: "-12suffix",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-conn.Context().Done():
+				want := "nethernet: remote peer notified connection failure (code: -12)"
+				if got := context.Cause(conn.Context()).Error(); got != want {
+					t.Fatalf("connection cause = %q, want %q", got, want)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("parsed error signal did not close the connection")
+			}
+		})
+	}
+}

--- a/dial.go
+++ b/dial.go
@@ -432,7 +432,7 @@ type dialerNotifier struct {
 
 // NotifySignal notifies an incoming Signal received from the Signaling implementation.
 func (d *dialerNotifier) NotifySignal(signal *Signal) bool {
-	if signal.ConnectionID != d.ConnectionID || signal.NetworkID != d.networkID {
+	if signal.ConnectionID != d.ConnectionID || signal.NetworkID != d.networkID || signal.validate() != nil {
 		return false
 	}
 	select {

--- a/dial_test.go
+++ b/dial_test.go
@@ -84,3 +84,53 @@ func (s *blockingErrorSignaling) NetworkID() string {
 }
 
 func (*blockingErrorSignaling) PongData([]byte) {}
+
+func TestDialerNotifierDropsMalformedSignals(t *testing.T) {
+	n := &dialerNotifier{Dialer: Dialer{ConnectionID: 42}, networkID: "server", ctx: t.Context(), signals: make(chan *Signal, 1)}
+	for _, signal := range []*Signal{
+		{Type: SignalTypeError, Data: "invalid"},
+		{Type: SignalTypeError, Data: "2147483648"},
+		{Type: "UNKNOWN", Data: "data"},
+	} {
+		signal.ConnectionID, signal.NetworkID = 42, "server"
+		if n.NotifySignal(signal) {
+			t.Fatalf("NotifySignal(%q, %q) accepted malformed signal", signal.Type, signal.Data)
+		}
+		if len(n.signals) != 0 {
+			t.Fatal("malformed signal consumed dialer queue capacity")
+		}
+	}
+}
+
+func TestDialerIgnoresMalformedSignalsBeforeAnswer(t *testing.T) {
+	client, server := newMemorySignalingPair("client", "server")
+	t.Cleanup(client.close)
+	t.Cleanup(server.close)
+	_, clientConn, serverConn := dialAcceptedListener(t, client, malformedBeforeAnswerSignaling{server})
+	checkConnPayload(t, clientConn, serverConn, []byte("handshake survived malformed signals"))
+	if got := client.signalCount(SignalTypeError); got != 0 {
+		t.Fatalf("client sent %d error replies to malformed signals", got)
+	}
+}
+
+// malformedBeforeAnswerSignaling injects invalid signals before forwarding the answer.
+type malformedBeforeAnswerSignaling struct{ Signaling }
+
+// Signal delivers malformed signals while the dialer is still waiting for its answer.
+func (s malformedBeforeAnswerSignaling) Signal(ctx context.Context, signal *Signal) error {
+	if signal.Type == SignalTypeAnswer {
+		for _, injected := range []Signal{
+			{Type: SignalTypeError, Data: "invalid"},
+			{Type: SignalTypeError, Data: ""},
+			{Type: SignalTypeError, Data: "+1"},
+			{Type: SignalTypeError, Data: "2147483648"},
+			{Type: "UNKNOWN", Data: "data"},
+		} {
+			injected.NetworkID, injected.ConnectionID = signal.NetworkID, signal.ConnectionID
+			if err := s.Signaling.Signal(ctx, &injected); err != nil {
+				return err
+			}
+		}
+	}
+	return s.Signaling.Signal(ctx, signal)
+}

--- a/listener.go
+++ b/listener.go
@@ -260,8 +260,8 @@ const (
 )
 
 // handleSignal handles the given Signal received from the remote network.
-// Candidate and error signals are deferred until the Conn is established in the background.
-// Once the Conn is established, it directly calls [Conn.handleSignal].
+// Candidates are deferred until the offer publishes its Conn.
+// Valid remote errors cancel pending work or close the published Conn immediately.
 func (n *listenerNegotiator) handleSignal(signal *Signal) bool {
 	select {
 	case <-n.closed:
@@ -274,10 +274,6 @@ func (n *listenerNegotiator) handleSignal(signal *Signal) bool {
 		// close the original peer. Reject it without sending a connection error.
 		return false
 	case SignalTypeError:
-		if _, err := strconv.ParseUint(signal.Data, 10, 32); err != nil {
-			n.log().Error("error parsing remote error code", "error", err)
-			return false
-		}
 		n.mu.Lock()
 		n.remoteCanceled.Store(true)
 		conn := n.conn
@@ -802,6 +798,9 @@ func (l *Listener) PongData(b []byte) {
 // NotifySignal handles an incoming Signal from the remote network and reports
 // whether it was accepted for processing.
 func (l *Listener) NotifySignal(signal *Signal) bool {
+	if signal.validate() != nil {
+		return false
+	}
 	l.negotiationsMu.Lock()
 	select {
 	case <-l.Context().Done():

--- a/listener_test.go
+++ b/listener_test.go
@@ -475,7 +475,7 @@ func TestListenerRemoteCancellationReleasesPendingOffers(t *testing.T) {
 		waitForCredentialRequest(t, base.started, "pending offer")
 	}
 	// A malformed error must neither cancel the offer nor consume deferred capacity.
-	for _, data := range []string{"invalid", "-1", "4294967296"} {
+	for _, data := range []string{"invalid", "-", "2147483648"} {
 		if l.NotifySignal(&Signal{Type: SignalTypeError, NetworkID: "remote", ConnectionID: 0, Data: data}) {
 			t.Fatalf("malformed error %q was accepted", data)
 		}

--- a/signal.go
+++ b/signal.go
@@ -120,18 +120,52 @@ func (s *Signal) MarshalText() ([]byte, error) {
 
 // UnmarshalText decodes the text into the Signal. An error may be returned, if the text
 // is invalid or does not follow the format '[Signal.Type] [Signal.ConnectionID] [Signal.Data]'.
+// Numeric fields accept decimal prefixes, including trailing text, as in the vanilla client.
+// Unknown signal types and error codes that cannot be parsed as signed 32-bit integers are rejected.
 func (s *Signal) UnmarshalText(b []byte) (err error) {
 	segments := bytes.SplitN(b, []byte{' '}, 3)
 	if len(segments) != 3 {
 		return fmt.Errorf("unexpected segmentations: %d", len(segments))
 	}
 	s.Type = string(segments[0])
-	s.ConnectionID, err = strconv.ParseUint(string(segments[1]), 10, 64)
+	s.ConnectionID, err = strconv.ParseUint(decimalPrefix(string(segments[1]), false), 10, 64)
 	if err != nil {
 		return fmt.Errorf("parse ConnectionID: %w", err)
 	}
 	s.Data = string(segments[2])
-	return nil
+	return s.validate()
+}
+
+// validate checks signal types and error codes before a signal reaches a connection.
+// Signaling implementations may construct Signals directly instead of decoding text.
+func (s *Signal) validate() error {
+	switch s.Type {
+	case SignalTypeOffer, SignalTypeAnswer, SignalTypeCandidate:
+		return nil
+	case SignalTypeError:
+		_, err := parseSignalErrorCode(s.Data)
+		return err
+	default:
+		return fmt.Errorf("unknown signal type: %s", s.Type)
+	}
+}
+
+// parseSignalErrorCode decodes a signed 32-bit decimal prefix, as the vanilla client does.
+func parseSignalErrorCode(data string) (int64, error) {
+	return strconv.ParseInt(decimalPrefix(data, true), 10, 32)
+}
+
+// decimalPrefix returns the initial decimal number without accepting '+' or whitespace.
+// A leading '-' is allowed only for signed fields. Conversion still checks for overflow.
+func decimalPrefix(s string, signed bool) string {
+	i := 0
+	if signed && len(s) > 0 && s[0] == '-' {
+		i++
+	}
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	return s[:i]
 }
 
 // String returns a string representation of the Signal in the format

--- a/signal_test.go
+++ b/signal_test.go
@@ -1,0 +1,69 @@
+package nethernet
+
+import "testing"
+
+func TestSignalUnmarshalText(t *testing.T) {
+	for _, test := range []struct {
+		text  string
+		id    uint64
+		valid bool
+	}{
+		{"CONNECTERROR 42 12", 42, true},
+		{"CONNECTERROR 42junk -12suffix", 42, true},
+		{"CONNECTERROR 0x10 0x10", 0, true},
+		{"CONNECTERROR 18446744073709551615 2147483647", ^uint64(0), true},
+		{"CONNECTERROR 42 -2147483648", 42, true},
+		{"CONNECTERROR 42 2147483648", 0, false},
+		{"CONNECTERROR 42 -2147483649", 0, false},
+		{"CONNECTERROR 42 invalid", 0, false},
+		{"CONNECTERROR 42 ", 0, false},
+		{"CONNECTERROR 42 -", 0, false},
+		{"CONNECTERROR 42 +12", 0, false},
+		{"CONNECTERROR 42  12", 0, false},
+		{"CONNECTERROR 42\t12", 0, false},
+		{"CONNECTERROR 18446744073709551616 12", 0, false},
+		{"CONNECTERROR -42 12", 0, false},
+		{"CONNECTERROR +42 12", 0, false},
+		{"CONNECTERROR  42 12", 0, false},
+		{"CONNECTERROR invalid 12", 0, false},
+		{"UNKNOWN 42 12", 0, false},
+		{"connecterror 42 12", 0, false},
+		{"CONNECTREQUEST 42junk offer data", 42, true},
+		{"CONNECTRESPONSE 42junk answer data", 42, true},
+		{"CANDIDATEADD 42junk candidate data", 42, true},
+	} {
+		t.Run(test.text, func(t *testing.T) {
+			var signal Signal
+			err := signal.UnmarshalText([]byte(test.text))
+			if (err == nil) != test.valid {
+				t.Fatalf("UnmarshalText() error = %v, valid = %t", err, test.valid)
+			}
+			if test.valid && signal.ConnectionID != test.id {
+				t.Fatalf("ConnectionID = %d, want %d", signal.ConnectionID, test.id)
+			}
+		})
+	}
+}
+
+func TestParseSignalErrorCode(t *testing.T) {
+	for _, test := range []struct {
+		data string
+		want int64
+	}{
+		{"0", 0},
+		{"0x10", 0},
+		{"12junk", 12},
+		{"12 ", 12},
+		{"-12suffix", -12},
+		{"2147483647", 2147483647},
+		{"-2147483648", -2147483648},
+		{"0000000000000000000000000000000000000012", 12},
+	} {
+		t.Run(test.data, func(t *testing.T) {
+			got, err := parseSignalErrorCode(test.data)
+			if err != nil || got != test.want {
+				t.Fatalf("parseSignalErrorCode(%q) = %d, %v; want %d, nil", test.data, got, err, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Malformed `CONNECTERROR` values and unknown signal types can abort a dial before its SDP answer. Validate incoming signals before listener/dialer dispatch so unparseable errors and unknown signal types are discarded, including when a `Signaling` implementation constructs `Signal` values directly.

Match the text parser's numeric rules to the reconstructed Bedrock **1.26.50.26** client receive routine (RVA `0xe246d0`): connection IDs use unsigned 64-bit decimal prefixes, while error codes use signed 32-bit decimal prefixes. This accepts inputs such as `42suffix` and `-12suffix`, rejects overflow and leading `+`/whitespace, and shares error-code validation across both peers. Also correct the listener comment describing deferred candidates and immediate remote-error cancellation.

The vanilla routine dispatches a `ConnectError` only after successful numeric conversion. Failed conversion returns before session lookup. Humanized equivalent of the relevant branch:

```cpp
if (type == "CONNECTERROR") {
    uint64_t connectionId;
    int32_t errorCode;
    if (from_chars(idText, connectionId).ec != errc{}) return;
    if (from_chars(data, errorCode).ec != errc{}) return;
    // The original checks conversion status, without requiring full consumption.
    dispatch(ConnectError{connectionId, errorCode});
}
```

Validation: parser boundary cases; rejection before dialing queue admission; a successful handshake after malformed signals before the answer; data transfer on both established peers after malformed signals; and a following valid signed-prefix error that closes with the expected cause. `go test -race ./...`, `go vet ./...`, and `staticcheck ./...` pass.
