### PR TITLE
conn: Close remote-error transports asynchronously

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -80,8 +80,10 @@ type Conn struct {
 	readMu  sync.Mutex
 	readBuf []byte
 
-	// once ensures that the Conn is closed only once.
+	// once ensures that the Conn transports are closed only once.
 	once sync.Once
+	// asyncCloseOnce starts at most one background cleanup per Conn.
+	asyncCloseOnce sync.Once
 
 	log *slog.Logger
 
@@ -94,7 +96,7 @@ type Conn struct {
 	// ctx is the background context associated with the Conn.
 	ctx context.Context
 	// cancel is the function used to cancel the ctx with a cause.
-	// It is called by close and must not be called elsewhere.
+	// It is called by close and closeAsync; the first cause is preserved.
 	cancel context.CancelCauseFunc
 }
 
@@ -332,6 +334,19 @@ func (conn *Conn) close(cause error) (err error) {
 	return err
 }
 
+// closeAsync cancels the Conn immediately and closes its transports in the background.
+// Signaling callbacks can return without waiting for transport cleanup.
+func (conn *Conn) closeAsync(cause error) {
+	conn.cancel(cause)
+	conn.asyncCloseOnce.Do(func() {
+		go func() {
+			if err := conn.close(cause); err != nil {
+				conn.log.Error("error closing conn", slog.Any("error", err))
+			}
+		}()
+	})
+}
+
 // channel returns the dataChannel for the given MessageReliability.
 func (conn *Conn) channel(r MessageReliability) *dataChannel {
 	conn.channelsMu.RLock()
@@ -406,7 +421,8 @@ func (conn *Conn) handleTransports() {
 // If the Signal is of SignalTypeCandidate, it parses a [webrtc.ICECandidate] from its data and
 // adds it to the ICE transport of the Conn.
 //
-// If the Signal is of SignalTypeError, it closes the Conn immediately.
+// If the Signal is of SignalTypeError, it cancels the Conn immediately and closes
+// its transports in the background.
 func (conn *Conn) handleSignal(signal *Signal) error {
 	select {
 	case <-conn.Context().Done():
@@ -428,9 +444,7 @@ func (conn *Conn) handleSignal(signal *Signal) error {
 		if err != nil {
 			return fmt.Errorf("parse error code: %w", err)
 		}
-		if err := conn.close(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code)); err != nil {
-			return fmt.Errorf("close: %w", err)
-		}
+		conn.closeAsync(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code))
 	default:
 		return fmt.Errorf("unknown signal type: %s", signal.Type)
 	}

--- a/conn.go
+++ b/conn.go
@@ -82,8 +82,6 @@ type Conn struct {
 
 	// once ensures that the Conn transports are closed only once.
 	once sync.Once
-	// asyncCloseOnce starts at most one background cleanup per Conn.
-	asyncCloseOnce sync.Once
 
 	log *slog.Logger
 
@@ -96,7 +94,7 @@ type Conn struct {
 	// ctx is the background context associated with the Conn.
 	ctx context.Context
 	// cancel is the function used to cancel the ctx with a cause.
-	// It is called by close and closeAsync; the first cause is preserved.
+	// The first cause is preserved.
 	cancel context.CancelCauseFunc
 }
 
@@ -334,19 +332,6 @@ func (conn *Conn) close(cause error) (err error) {
 	return err
 }
 
-// closeAsync cancels the Conn immediately and closes its transports in the background.
-// Signaling callbacks can return without waiting for transport cleanup.
-func (conn *Conn) closeAsync(cause error) {
-	conn.cancel(cause)
-	conn.asyncCloseOnce.Do(func() {
-		go func() {
-			if err := conn.close(cause); err != nil {
-				conn.log.Error("error closing conn", slog.Any("error", err))
-			}
-		}()
-	})
-}
-
 // channel returns the dataChannel for the given MessageReliability.
 func (conn *Conn) channel(r MessageReliability) *dataChannel {
 	conn.channelsMu.RLock()
@@ -444,7 +429,9 @@ func (conn *Conn) handleSignal(signal *Signal) error {
 		if err != nil {
 			return fmt.Errorf("parse error code: %w", err)
 		}
-		conn.closeAsync(fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code))
+		cause := fmt.Errorf("nethernet: remote peer notified connection failure (code: %d)", code)
+		conn.cancel(cause)
+		go conn.close(cause)
 	default:
 		return fmt.Errorf("unknown signal type: %s", signal.Type)
 	}

--- a/listener.go
+++ b/listener.go
@@ -261,7 +261,8 @@ const (
 
 // handleSignal handles the given Signal received from the remote network.
 // Candidates are deferred until the offer publishes its Conn.
-// Valid remote errors cancel pending work or close the published Conn immediately.
+// Valid remote errors cancel pending work or the published Conn immediately.
+// Transport cleanup runs in the background.
 func (n *listenerNegotiator) handleSignal(signal *Signal) bool {
 	select {
 	case <-n.closed:

--- a/listener_test.go
+++ b/listener_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -972,4 +973,39 @@ func waitListenerResponse(t *testing.T, responses <-chan Signal) Signal {
 		t.Fatal("timed out waiting for listener response")
 		return Signal{}
 	}
+}
+
+func TestListenerRemoteErrorDoesNotWaitForTransportCleanup(t *testing.T) {
+	client, server := newMemorySignalingPair("client", "server")
+	t.Cleanup(client.close)
+	t.Cleanup(server.close)
+	l, _, conn := dialAcceptedListener(t, client, server)
+	addr := conn.RemoteAddr().(*Addr)
+	// Hold cleanup at the channel snapshot while the signaling callback runs.
+	conn.channelsMu.Lock()
+	unlock := sync.OnceFunc(conn.channelsMu.Unlock)
+	t.Cleanup(unlock)
+	returned := make(chan bool, 1)
+	go func() {
+		returned <- l.NotifySignal(&Signal{
+			Type: SignalTypeError, NetworkID: addr.NetworkID,
+			ConnectionID: addr.ConnectionID, Data: strconv.Itoa(ErrorCodeGenericFailure),
+		})
+	}()
+	select {
+	case accepted := <-returned:
+		if !accepted {
+			t.Fatal("remote error rejected")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("remote error blocked signaling on transport cleanup")
+	}
+	if cause := context.Cause(conn.ctx); cause == nil || !strings.Contains(cause.Error(), "remote peer notified connection failure") {
+		t.Fatalf("remote error returned before canceling connection: %v", cause)
+	}
+	unlock()
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitListenerState(t, l, 0, 0)
 }


### PR DESCRIPTION
A valid remote `CONNECTERROR` currently tears down transports inside the signaling callback. This can stall delivery of signals for other connections: Pion's `SCTPTransport.Stop()` calls `Association.Abort()`, which has a **200 ms abort-flush wait**, another possible **200 ms wait**, and a read-loop join. These are possible waits, not a fixed delay or a 200 ms upper bound for the whole close.

Cancel the connection immediately with the remote error cause, then close its transports in the background. The error handler cancels the connection and calls `go conn.close(cause)`, using the same background-close pattern as the transport callbacks. The existing `sync.Once` prevents duplicate transport teardown, and public `Conn.Close()` still waits for teardown to finish.

The regression test holds transport cleanup at the channel snapshot and verifies that the listener's signaling callback returns with the connection already canceled. It fails on the previous synchronous path and passes with this change.

Validation: `go test -race ./...`, `go vet ./...`, and `staticcheck ./...` pass. `codex review` with Astra medium found no actionable regressions.
